### PR TITLE
Refactor RelayRecipient - get_recipient_balance, etc

### DIFF
--- a/contracts/RelayRecipientApi.sol
+++ b/contracts/RelayRecipientApi.sol
@@ -2,5 +2,15 @@ pragma solidity ^0.4.18;
 
 contract RelayRecipientApi {
 
-    function get_relay_hub() external view returns (address);
+    /**
+     * return the relayHub of this contract.
+     */
+    function get_hub_addr() public view returns (address);
+
+    /**
+     * return the contract's balance on the RelayHub.
+     * can be used to determine if the contract can pay for incoming calls,
+     * before making any.
+     */
+    function get_recipient_balance() public view returns (uint);
 }

--- a/contracts/SampleRecipient.sol
+++ b/contracts/SampleRecipient.sol
@@ -8,16 +8,16 @@ contract SampleRecipient is RelayRecipient {
     mapping (address => bool) public relays_whitelist;
 
     constructor(RelayHub rhub) public {
-        relay_hub = rhub;
+        init_relay_hub(rhub);
     }
 
     function deposit() public payable {
-        RelayHub(relay_hub).deposit.value(msg.value)();
+        get_relay_hub().deposit.value(msg.value)();
     }
 
     function withdraw() public {
-        uint balance = RelayHub(relay_hub).balances(address(this));
-        RelayHub(relay_hub).withdraw(balance);
+        uint balance = get_relay_hub().balances(address(this));
+        get_relay_hub().withdraw(balance);
     }
 
     event Reverting(string message);

--- a/src/js/relayclient/RelayRecipientApi.js
+++ b/src/js/relayclient/RelayRecipientApi.js
@@ -1,1 +1,1 @@
-module.exports=[{"constant":true,"inputs":[],"name":"get_relay_hub","outputs":[{"name":"","type":"address"}],"payable":false,"stateMutability":"view","type":"function"}]
+module.exports=[{"constant":true,"inputs":[],"name":"get_hub_addr","outputs":[{"name":"","type":"address"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"get_recipient_balance","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"}]

--- a/src/js/relayclient/relayclient.js
+++ b/src/js/relayclient/relayclient.js
@@ -207,7 +207,7 @@ RelayClient.prototype.broadcastRawTx = function (raw_tx, tx_hash) {
  */
 RelayClient.prototype.balanceOf = async function (target) {
     let relayRecipient = this.RelayRecipient.at(target)
-    let relayHubAddress = await promisify(relayRecipient.get_relay_hub.call)()
+    let relayHubAddress = await promisify(relayRecipient.get_hub_addr.call)()
     let relayHub = this.RelayHub.at(relayHubAddress)
 
     //note that the returned value is a promise too, returning BigNumber
@@ -224,7 +224,7 @@ RelayClient.prototype.relayTransaction = async function (encodedFunctionCall, op
   var self = this
   let relayRecipient = this.RelayRecipient.at(options.to)
 
-  let relayHubAddress = await promisify(relayRecipient.get_relay_hub.call)()
+  let relayHubAddress = await promisify(relayRecipient.get_hub_addr.call)()
 
   let relayHub = this.RelayHub.at(relayHubAddress)
 
@@ -271,6 +271,9 @@ RelayClient.prototype.relayTransaction = async function (encodedFunctionCall, op
     } else {
       signature = await getTransactionSignature(options.from, hash);
     }
+    console.log( "hash=",hash, "from=",options.from, "sig=",signature)
+    let rec = utils.getEcRecoverMeta(hash, signature );
+    console.log( "== recovered=", rec, rec==options.from ? "OK" : "error: signature error" )
     try {
       let validTransaction = await self.sendViaRelay(
         relayUrl,

--- a/src/js/webtools/contractmanager.js
+++ b/src/js/webtools/contractmanager.js
@@ -9,6 +9,10 @@ const RelayRecipient = web3.eth.contract(RelayRecipientApi)
 
 class ContractManager {
 
+    constructor() {
+        utils.checkNetwork(web3)
+    }
+
     log() {
         utils.log(Array.prototype.slice.call(arguments).join(" "))
     }
@@ -25,7 +29,7 @@ class ContractManager {
 
         let recipient = RelayRecipient.at(addr)
 
-        let hubaddr = await promisify(recipient.get_relay_hub)()
+        let hubaddr = await promisify(recipient.get_hub_addr)()
 
         if (!hubaddr || hubaddr === '0x')
             return undefined
@@ -41,6 +45,7 @@ class ContractManager {
 
         if (!hub) {
             this.log("ERROR: no hub (address not a RelayRecipient?)")
+            return
         }
 
         let r = await promisify(hub.balanceOf)(addr)

--- a/src/js/webtools/relaymanager.js
+++ b/src/js/webtools/relaymanager.js
@@ -8,6 +8,10 @@ const networkVersions = { 1: "Mainnet", 42: "Kovan", 3: "Ropsten", 4: "Rinkeby",
 
 class RelayManager {
 
+    constructor() {
+        utils.checkNetwork(web3)
+    }
+
     log() {
         utils.log(Array.prototype.slice.call(arguments).join(" "))
     }

--- a/src/js/webtools/utils.js
+++ b/src/js/webtools/utils.js
@@ -4,7 +4,7 @@ module.exports = {
     checkNetwork: function(web3) {
 
         setTimeout(()=>{
-            ver = web3.version.network
+            let ver = web3.version.network
 
             web3.version.getNetwork((e,r)=>{
                 if ( r != ver ) {

--- a/src/js/webtools/utils.js
+++ b/src/js/webtools/utils.js
@@ -1,6 +1,21 @@
 
 module.exports = {
 
+    checkNetwork: function(web3) {
+
+        setTimeout(()=>{
+            ver = web3.version.network
+
+            web3.version.getNetwork((e,r)=>{
+                if ( r != ver ) {
+                    console.log("ERROR: Metamask version mismatch", r, "!=", ver)
+                    console.log("Probably Metamask didn't notice ganache restart. Switch network, and back")
+                }
+            })
+
+        }, 100)
+    },
+
     //dump log string into <div id='logpanel'> (or to console log, if no such panel)
     log: function () {
         let argstr = Array.prototype.slice.call(arguments).join(" ");

--- a/test/flows.js
+++ b/test/flows.js
@@ -52,7 +52,8 @@ options.forEach(params => {
                 from = gasless
             } else {
                 from = accounts[0]
-                rhub = {address: "0x0"} //dummy relay hub. direct mode doesn't use it, but our SampleRecipient contract requires one.
+                //dummy relay hub. direct mode doesn't use it, but our SampleRecipient contract requires one.
+                rhub = await RelayHub.deployed()
             }
 
             sr = await SampleRecipient.new(rhub.address)


### PR DESCRIPTION
- added get_recipient_balance() to check balance (and also validate the
existence of the hub)
- call it from `set_relay_hub_internal()`
- make `relay_hub` member private (to require setter and getter)
- added `get_relay_hub()` to return it as RelayHub, and separate
`get_hub_addr()`, which is used from RelayRecipientApi