### PR TITLE
support multiple solc versions

### DIFF
--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.4.0 <0.6.0;
 
 contract Migrations {
   address public owner;

--- a/contracts/RLPReader.sol
+++ b/contracts/RLPReader.sol
@@ -2,7 +2,7 @@
 * Taken from https://github.com/hamdiallam/Solidity-RLP
 */
 
-pragma solidity ^0.5.0;
+pragma solidity >=0.4.0 <0.6.0;
 
 library RLPReader {
 

--- a/contracts/RecipientUtils.sol
+++ b/contracts/RecipientUtils.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.4.0 <0.6.0;
 
 contract RecipientUtils {
 

--- a/contracts/RelayHub.sol
+++ b/contracts/RelayHub.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.4.0 <0.6.0;
 
 import "./RelayHubApi.sol";
 import "./RelayRecipient.sol";

--- a/contracts/RelayHubApi.sol
+++ b/contracts/RelayHubApi.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.4.0 <0.6.0;
 
 contract  RelayHubApi {
 

--- a/contracts/RelayRecipient.sol
+++ b/contracts/RelayRecipient.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.4.0 <0.6.0;
 
 // Contract that implements the relay recipient protocol.  Inherited by Gatekeeper, or any other relay recipient.
 //
@@ -97,7 +97,7 @@ contract RelayRecipient is RelayRecipientApi {
 	 *  @param gas_price - the gas price for this transaction
 	 *  @param transaction_fee - the relay compensation (in %) for this transaction
 	 */
-    function accept_relayed_call(address relay, address from, bytes calldata encoded_function, uint gas_price, uint transaction_fee ) external view returns(uint32);
+    function accept_relayed_call(address relay, address from, bytes memory encoded_function, uint gas_price, uint transaction_fee ) public view returns(uint32);
 
     /**
      * This method is called after the relayed call.
@@ -107,7 +107,7 @@ contract RelayRecipient is RelayRecipientApi {
      * - used_gas - gas used up to this point. Note that gas calculation (for the purpose of compensation
      *   to the relay) is done after this method returns.
      */
-    function post_relayed_call(address relay, address from, bytes calldata encoded_function, bool success, uint used_gas, uint transaction_fee ) external;
+    function post_relayed_call(address relay, address from, bytes memory encoded_function, bool success, uint used_gas, uint transaction_fee ) public;
 
     function bytesToAddress(bytes memory b) private pure returns (address addr) {
         assembly {

--- a/contracts/RelayRecipientApi.sol
+++ b/contracts/RelayRecipientApi.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.4.0 <0.6.0;
 
 contract RelayRecipientApi {
 

--- a/contracts/SampleRecipient.sol
+++ b/contracts/SampleRecipient.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.4.0 <0.6.0;
 
 import "./RelayHub.sol";
 import "./RelayRecipient.sol";
@@ -44,7 +44,7 @@ contract SampleRecipient is RelayRecipient {
         blacklisted = addr;
     }
 
-    function accept_relayed_call(address relay, address from, bytes calldata /*encoded_function*/, uint /*gas_price*/, uint /*transaction_fee*/ ) external view returns(uint32) {
+    function accept_relayed_call(address relay, address from, bytes memory /*encoded_function*/, uint /*gas_price*/, uint /*transaction_fee*/ ) public view returns(uint32) {
         // The factory accepts relayed transactions from anyone, so we whitelist our own relays to prevent abuse.
         // This protection only makes sense for contracts accepting anonymous calls, and therefore not used by Gatekeeper or Multisig.
         // May be protected by a user_credits map managed by a captcha-protected web app or association with a google account.
@@ -56,7 +56,7 @@ contract SampleRecipient is RelayRecipient {
 
     event SampleRecipientPostCall(uint used_gas );
 
-    function post_relayed_call(address /*relay*/ , address /*from*/, bytes calldata /*encoded_function*/, bool /*success*/, uint used_gas, uint transaction_fee ) external {
+    function post_relayed_call(address /*relay*/ , address /*from*/, bytes memory /*encoded_function*/, bool /*success*/, uint used_gas, uint transaction_fee ) public {
 
         emit SampleRecipientPostCall(used_gas * tx.gasprice * (transaction_fee+100)/100);
     }

--- a/contracts/TestRecipientUtils.sol
+++ b/contracts/TestRecipientUtils.sol
@@ -1,11 +1,11 @@
-pragma solidity ^0.5.0;
+pragma solidity >=0.4.0 <0.6.0;
 
 import './RecipientUtils.sol';
 
 contract TestRecipientUtils is RecipientUtils {
 
     event Unused();
-    function testFunc(uint , string calldata, uint , bytes calldata ) external {
+    function testFunc(uint , string memory, uint , bytes memory ) public {
         emit Unused();  //just to avoid warnings..
     }
 


### PR DESCRIPTION
support multi solc versions.
make the code compile-able and workable with solc 0.4.x, 0.5.x
(requires us to use "public" for some "external" functions, the ABI stays intact when compiled with either compiler)