### PR TITLE
Fixes for browser and metamask

### DIFF
--- a/server/src/RelayHttpServer.go
+++ b/server/src/RelayHttpServer.go
@@ -62,6 +62,10 @@ func main() {
 // http.HandlerFunc wrapper to assure we have enough balance to operate, and server already has stake and registered
 func assureRelayReady(fn http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+
+		w.Header()[ "Access-Control-Allow-Origin"] = []string{"*"}
+		w.Header()[ "Access-Control-Allow-Headers"] = []string{"*"}
+
 		if !ready.GetVal() {
 			err := fmt.Errorf("Relay not staked and registered yet")
 			log.Println(err)

--- a/src/js/relayclient/relayclient.js
+++ b/src/js/relayclient/relayclient.js
@@ -1,4 +1,3 @@
-/* global web3 */
 const utils = require('./utils')
 const getTransactionSignature = utils.getTransactionSignature;
 const getTransactionSignatureWithKey = utils.getTransactionSignatureWithKey;
@@ -54,11 +53,11 @@ function RelayClient(web3, config) {
 }
 
 RelayClient.prototype.createRelayRecipient = function(addr) {
-    return new web3.eth.Contract(relayRecipientAbi, addr)
+    return new this.web3.eth.Contract(relayRecipientAbi, addr)
 }
 
 RelayClient.prototype.createRelayHub = function(addr) {
-    return new web3.eth.Contract(relayHubAbi, addr)
+    return new this.web3.eth.Contract(relayHubAbi, addr)
 }
 
 /**
@@ -249,12 +248,12 @@ RelayClient.prototype.relayTransaction = async function (encodedFunctionCall, op
 
   let gasPrice = this.config.force_gasPrice ||  //forced gasprice
                     options.gas_price ||        //user-supplied gas price
-                    ( await web3.eth.getGasPrice() ) * (pct+100)/100
+                    ( await this.web3.eth.getGasPrice() ) * (pct+100)/100
 
     //TODO: should add gas estimation for encodedFunctionCall (tricky, since its not a real transaction)
   let gasLimit = this.config.force_gasLimit || options.gas_limit
 
-  let blockNow = await web3.eth.getBlockNumber()
+  let blockNow = await this.web3.eth.getBlockNumber()
   let blockDayAgo = Math.max(1, blockNow - est_blocks_per_day)
   let pinger = await this.serverHelper.newActiveRelayPinger(blockDayAgo, gasPrice)
   for (;;) {


### PR DESCRIPTION
Add "Access-Control" headers also on error - otherwise, cannot access response
Remove global web3 from relay client use.