### PR TITLE
Add 'webtools.webpack.js' to package to run webtools without clone

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "src/",
     "contracts/",
     "webtools/",
-    "samples/"
+    "samples/",
+    "webtools.webpack.js"
   ],
   "main": "src/js/relayclient/index.js",
   "description": "Tabookey Gasless Relay Framework"


### PR DESCRIPTION
For projects that install 'tabookey-gasless' as a dependency, use this command to run web tools instead of cloning entire repository:
npm explore tabookey-gasless -- npm run webtools