### PR TITLE
GLS-50 In RelayHub, verify that relays are not contracts

### DIFF
--- a/contracts/RelayHub.sol
+++ b/contracts/RelayHub.sol
@@ -148,6 +148,7 @@ contract RelayHub is RelayHubApi {
         Stake storage relay_stake = stakes[msg.sender];
         // Penalized relay cannot reregister
         require(!relay_stake.removed, "Penalized relay cannot reregister");
+        require(msg.sender == tx.origin, "Contracts cannot register as relays");
         relays[msg.sender] = Relay(now, transaction_fee);
         emit RelayAdded(msg.sender, relay_stake.owner, transaction_fee, relay_stake.stake, relay_stake.unstake_delay, url);
 

--- a/contracts/TestRecipientUtils.sol
+++ b/contracts/TestRecipientUtils.sol
@@ -1,6 +1,7 @@
 pragma solidity >=0.4.0 <0.6.0;
 
 import './RecipientUtils.sol';
+import './RelayHub.sol';
 
 contract TestRecipientUtils is RecipientUtils {
 
@@ -9,4 +10,9 @@ contract TestRecipientUtils is RecipientUtils {
         emit Unused();  //just to avoid warnings..
     }
 
+    function registerAsRelay(RelayHub relayhub) public payable {
+        relayhub.stake.value(msg.value)(address(this), 1);
+        relayhub.register_relay(10, "string memory url", address(0));
+    }
+    function() external payable {}
 }

--- a/test/relay_contract.js
+++ b/test/relay_contract.js
@@ -3,6 +3,7 @@
 const Big = require( 'big.js' )
 
 const SampleRecipient = artifacts.require("./SampleRecipient.sol");
+const TestRecipientUtils = artifacts.require("./TestRecipientUtils.sol");
 
 const testutils = require('./testutils')
 const utils = require('../src/js/relayclient/utils')
@@ -94,7 +95,15 @@ contract("RelayHub", function (accounts) {
         assert.equal(expected_stake, stake[0] );
     })
 
-    it("test_register_relay", async function () {
+    it("Should allow externally owned addresses to register as relays", async function () {
+        let testutils = await TestRecipientUtils.new()
+        try {
+            await web3.eth.sendTransaction({from: accounts[0], to: testutils.address, value: 0.6e18})
+            await testutils.registerAsRelay(rhub.address, {value: 1e18});
+            assert.fail();
+        } catch (error) {
+            assertErrorMessageCorrect(error, "Contracts cannot register as relays")
+        }
         let res = await register_new_relay(rhub, one_ether, dayInSec, 120, "hello", accounts[0]);
         let log = res.logs[0]
         assert.equal("RelayAdded", log.event)

--- a/test/relay_contract.js
+++ b/test/relay_contract.js
@@ -95,7 +95,7 @@ contract("RelayHub", function (accounts) {
         assert.equal(expected_stake, stake[0] );
     })
 
-    it("Should allow externally owned addresses to register as relays", async function () {
+    it("should forbid contracts-owned addresses to register as relays", async function(){
         let testutils = await TestRecipientUtils.new()
         try {
             await web3.eth.sendTransaction({from: accounts[0], to: testutils.address, value: 0.6e18})
@@ -104,6 +104,9 @@ contract("RelayHub", function (accounts) {
         } catch (error) {
             assertErrorMessageCorrect(error, "Contracts cannot register as relays")
         }
+    })
+
+    it("should allow externally owned addresses to register as relays", async function () {
         let res = await register_new_relay(rhub, one_ether, dayInSec, 120, "hello", accounts[0]);
         let log = res.logs[0]
         assert.equal("RelayAdded", log.event)


### PR DESCRIPTION
There is no legitimate reason for a relay address to be controlled by a
smart contract within our design of Relay Network.
Making sure that message sender is the transaction origin is the safest
way to validate the caller is externally-owned.