### PR TITLE
Fix typo in dockprefix variable

### DIFF
--- a/dock/run.sh
+++ b/dock/run.sh
@@ -10,7 +10,7 @@ folders="`pwd` /Users /home"
 #folder_maps="build node_modules"
 
 #absolute prefix, where following folders are placed.
-DOCKPREFIX=~/build/$DOCKANE-folders/
+DOCKPREFIX=~/build/$DOCKNAME-folders/
 mkdir -p $DOCKPREFIX
 
 #following folders are mapped under DOCKPREFIX, so they are kept on the host, but separate from


### PR DESCRIPTION
In the docker run script, dockprefix (the base folder where others are later placed) uses DOCKNAME as part of the folder name, but a typo was causing the folder to be named `build/-folders` instead of `build/relaydock-folders`.