### PR TITLE
HTTP timeout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -448,6 +448,15 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
+      }
+    },
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
@@ -2340,7 +2349,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
       "integrity": "sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==",
-      "dev": true,
       "requires": {
         "debug": "=3.1.0"
       },
@@ -2349,7 +2357,6 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -2486,7 +2493,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2507,12 +2515,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2527,17 +2537,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2654,7 +2667,8 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2666,6 +2680,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2680,6 +2695,7 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2687,12 +2703,14 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2711,6 +2729,7 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2791,7 +2810,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2803,6 +2823,7 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2888,7 +2909,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2924,6 +2946,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2943,6 +2966,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2986,12 +3010,14 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "optional": true
         }
       }
     },
@@ -7553,7 +7579,7 @@
       "requires": {
         "underscore": "1.8.3",
         "web3-core-helpers": "1.0.0-beta.37",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
       },
       "dependencies": {
         "websocket": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -401,6 +401,12 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -893,6 +899,29 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "requires": {
+        "check-error": "^1.0.2"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -907,6 +936,12 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "check-types": {
@@ -1393,6 +1428,15 @@
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         }
+      }
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
       }
     },
     "deep-is": {
@@ -3475,6 +3519,12 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
     "get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -5068,6 +5118,12 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
     },
     "pbkdf2": {
       "version": "3.0.17",
@@ -6958,6 +7014,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.16",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "gsn-dock-relay-ganache": "./scripts/gsn-dock-relay-ganache"
   },
   "scripts": {
-    "test": "make test-server && run-with-testrpc -p 8544 -l 8000000 './node_modules/.bin/truffle --network npmtest test' ",
+    "test": "npm run test-server && npm run test-js",
+    "test-server": "make test-server",
+    "test-js": "run-with-testrpc -p 8544 -l 8000000 './node_modules/.bin/truffle --network npmtest test'",
     "webtools-pack": "webpack-cli --config ./webtools.webpack.js",
     "webtools": "webpack-cli --config ./webtools.webpack.js && http-server webtools/ -o",
     "lint": "eslint ./src ./test -f unix",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
   },
   "devDependencies": {
     "browser-request": "^0.3.3",
+    "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
     "eslint": "^5.12.1",
     "ganache-cli": "^6.2.5",
     "http-server": "^0.11.1",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "abi-decoder": "^1.2.0",
+    "axios": "^0.18.0",
     "big-js": "^3.1.3",
     "eth-crypto": "^1.2.7",
     "ethereumjs-tx": "^1.3.7",

--- a/src/js/relayclient/HttpWrapper.js
+++ b/src/js/relayclient/HttpWrapper.js
@@ -1,52 +1,41 @@
-var logreq = process.env.httpsendlog
-var unique_id = 1
+const axios = require('axios');
+const logreq = process.env.httpsendlog;
+const logmaxlen = 120
 
 class HttpWrapper {
 
-    constructor(web3) {
-        this.HttpProvider = web3.providers.HttpProvider
+    constructor(opts) {
+        this.provider = axios.create(Object.assign({
+            headers: { 'Content-Type': 'application/json' }
+        }, opts));
+
+        if (logreq) {
+            this.provider.interceptors.response.use(function (response) {
+                console.log("got response:", response.config.url, JSON.stringify(response.data).slice(0, logmaxlen))
+                return response;
+            }, function (error) {
+                const errData = error.response ? error.response.data : { error: error.message };
+                const errStr = ((typeof errData === 'string') ? errData : JSON.stringify(errData)).slice(0, logmaxlen);
+                const errUrl = error.response ? error.response.config.url : error.address;
+                console.log("got response:", errUrl, "err=", errStr);
+                return Promise.reject(error);
+            });
+        }
     }
 
     send(url, jsonRequestData, callback) {
-        let maxlen = 120
-
-        jsonRequestData = jsonRequestData || {}
-        let localid = unique_id++
-        if (logreq) {
-            console.log("sending request:", localid, url, JSON.stringify(jsonRequestData).slice(0, maxlen))
-        }
-
-        let callback1 = function (e, r) {
-            if (e && ("" + e).indexOf("Invalid JSON RPC response") >= 0) {
-                e = {error: "invalid-json"}
-            }
-            if (("" + r).indexOf("\"error\"") >= 0) {
-                e = r;
-                r = null;
-            }
-            if (!e && r && r.error) {
-                e = r;
-                r = null
-            }
-            if (logreq) {
-                console.log("got response:", localid, JSON.stringify(r).slice(0, maxlen), "err=", JSON.stringify(e).slice(0, maxlen))
-            }
-            callback(e, r)
-        }
-
-        let provider = new this.HttpProvider(url)
-        let send = provider['sendAsync'] || provider['send']
-        send.bind(provider)(jsonRequestData, callback1);
+        this.sendPromise(url, jsonRequestData || {})
+            .then(data => callback(null, data))
+            .catch(err => callback(err, null));
     }
 
     sendPromise(url, jsonRequestData) {
-        let self = this
-        return new Promise((resolve, reject) => {
-            self.send(url, jsonRequestData, (e, r) => {
-                if (e) return reject(e)
-                return resolve(r)
-            })
-        })
+        if (logreq) {
+            console.log("sending request:", url, JSON.stringify(jsonRequestData || {}).slice(0, logmaxlen))
+        }
+        return this.provider.post(url, jsonRequestData)
+            .then(res => res.data)
+            .catch(err => Promise.reject(err.response ? err.response.data : { error: err.message }));
     }
 }
 

--- a/src/js/relayclient/RelayClient.js
+++ b/src/js/relayclient/RelayClient.js
@@ -42,7 +42,7 @@ class RelayClient {
         // TODO: require sign() or privKey
         this.config = config || {};
         this.web3 = web3;
-        this.httpSend = new HttpWrapper(this.web3);
+        this.httpSend = new HttpWrapper();
         this.serverHelper = this.config.serverHelper || new ServerHelper(this.config.minStake || 0, this.config.minDelay || 0, this.httpSend, this.config.verbose)
     }
 

--- a/src/js/relayclient/RelayClient.js
+++ b/src/js/relayclient/RelayClient.js
@@ -18,6 +18,9 @@ const relayRecipientAbi = require('./RelayRecipientApi');
 const relay_lookup_limit_blocks = 6000;
 abi_decoder.addABI(relayHubAbi);
 
+// default timeout (in ms) for http requests
+const DEFAULT_HTTP_TIMEOUT = 10000;
+
 //default gas price (unless client specifies one): the web3.eth.gasPrice*(100+GASPRICE_PERCENT)/100
 const GASPRICE_PERCENT = 20;
 
@@ -42,7 +45,7 @@ class RelayClient {
         // TODO: require sign() or privKey
         this.config = config || {};
         this.web3 = web3;
-        this.httpSend = new HttpWrapper();
+        this.httpSend = new HttpWrapper({ timeout: this.config.httpTimeout || DEFAULT_HTTP_TIMEOUT });
         this.serverHelper = this.config.serverHelper || new ServerHelper(this.config.minStake || 0, this.config.minDelay || 0, this.httpSend, this.config.verbose)
     }
 

--- a/test/http_wrapper_test.js
+++ b/test/http_wrapper_test.js
@@ -1,6 +1,9 @@
+const assert = require('chai')
+  .use(require('chai-as-promised'))
+  .assert;
+
 /* global describe web3 require assert it */
 const HttpWrapper = require('../src/js/relayclient/HttpWrapper')
-
 const Web3 = require('web3')
 
 describe("HttpWrapper", () => {
@@ -27,5 +30,19 @@ describe("HttpWrapper", () => {
             })
         })
         assert.equal( "err: {\"error\":\"connect ECONNREFUSED 127.0.0.1:44321\"}", res)
+    })
+
+    it("should timeout after specified time", async () => {
+        // this test abuses the fact that a local ganache is slow, and should take over 1ms to respond even if it's local
+        const http = new HttpWrapper({ timeout: 1 });
+        let error = null;
+        await assert.isRejected(
+            http.sendPromise(web3.currentProvider.host, {jsonrpc: "2.0", method: "net_version", id:123})
+                .catch(err => {
+                    error = err;
+                    return Promise.reject(err);
+                })
+        );
+        assert.deepEqual(error, { error: 'timeout of 1ms exceeded' });
     })
 })

--- a/test/http_wrapper_test.js
+++ b/test/http_wrapper_test.js
@@ -5,7 +5,7 @@ const Web3 = require('web3')
 
 describe("HttpWrapper", () => {
     it("global web3: connect to node, get version", async () => {
-        let http = new HttpWrapper(web3);
+        let http = new HttpWrapper();
 
         let res = await new Promise((resolve) => {
             let url = web3.currentProvider.host
@@ -18,19 +18,20 @@ describe("HttpWrapper", () => {
 
         assert.equal( 123, res.id, JSON.stringify(res) ) //just verify its a valid response
     })
+    
     it("global web3: should fail on connection refused", async () => {
-        let http = new HttpWrapper(web3);
+        let http = new HttpWrapper();
         let res = await new Promise((resolve) => {
             http.send("http://localhost:44321", {jsonrpc: "2.0", method: "net_version", id:123}, (e, r) => {
                 if (e) resolve( "err: "+JSON.stringify(e))
                 resolve(r)
             })
         })
-        assert.equal( "err: {\"error\":\"invalid-json\"}", res)
+        assert.equal( "err: {\"error\":\"connect ECONNREFUSED 127.0.0.1:44321\"}", res)
     })
 
     it("loaded Web3: connect to node, get version", async () => {
-        let http = new HttpWrapper(Web3);
+        let http = new HttpWrapper();
 
         let res = await new Promise((resolve) => {
             let url = web3.currentProvider.host
@@ -42,14 +43,15 @@ describe("HttpWrapper", () => {
 
         assert.equal( 123, res.id, JSON.stringify(res) ) //just verify its a valid response
     })
+    
     it("loaded Web3: should fail on connection refused", async () => {
-        let http = new HttpWrapper(Web3);
+        let http = new HttpWrapper();
         let res = await new Promise((resolve) => {
             http.send("http://localhost:44321", {jsonrpc: "2.0", method: "net_version", id:123}, (e, r) => {
                 if (e) resolve( "err: "+JSON.stringify(e))
                 resolve(r)
             })
         })
-        assert.equal( "err: {\"error\":\"invalid-json\"}", res)
+        assert.equal( "err: {\"error\":\"connect ECONNREFUSED 127.0.0.1:44321\"}", res)
     })
 })

--- a/test/http_wrapper_test.js
+++ b/test/http_wrapper_test.js
@@ -4,9 +4,8 @@ const HttpWrapper = require('../src/js/relayclient/HttpWrapper')
 const Web3 = require('web3')
 
 describe("HttpWrapper", () => {
-    it("global web3: connect to node, get version", async () => {
+    it("connect to node, get version", async () => {
         let http = new HttpWrapper();
-
         let res = await new Promise((resolve) => {
             let url = web3.currentProvider.host
 
@@ -19,32 +18,7 @@ describe("HttpWrapper", () => {
         assert.equal( 123, res.id, JSON.stringify(res) ) //just verify its a valid response
     })
     
-    it("global web3: should fail on connection refused", async () => {
-        let http = new HttpWrapper();
-        let res = await new Promise((resolve) => {
-            http.send("http://localhost:44321", {jsonrpc: "2.0", method: "net_version", id:123}, (e, r) => {
-                if (e) resolve( "err: "+JSON.stringify(e))
-                resolve(r)
-            })
-        })
-        assert.equal( "err: {\"error\":\"connect ECONNREFUSED 127.0.0.1:44321\"}", res)
-    })
-
-    it("loaded Web3: connect to node, get version", async () => {
-        let http = new HttpWrapper();
-
-        let res = await new Promise((resolve) => {
-            let url = web3.currentProvider.host
-            http.send(url, {jsonrpc: "2.0", method: "net_version", id:123}, (e, r) => {
-                if (e) resolve( "err: "+JSON.stringify(e))
-                resolve(r)
-            })
-        })
-
-        assert.equal( 123, res.id, JSON.stringify(res) ) //just verify its a valid response
-    })
-    
-    it("loaded Web3: should fail on connection refused", async () => {
+    it("should fail on connection refused", async () => {
         let http = new HttpWrapper();
         let res = await new Promise((resolve) => {
             http.send("http://localhost:44321", {jsonrpc: "2.0", method: "net_version", id:123}, (e, r) => {

--- a/test/http_wrapper_test.js
+++ b/test/http_wrapper_test.js
@@ -1,10 +1,6 @@
-const assert = require('chai')
-  .use(require('chai-as-promised'))
-  .assert;
-
-/* global describe web3 require assert it */
+/* global describe web3 require it */
 const HttpWrapper = require('../src/js/relayclient/HttpWrapper')
-const Web3 = require('web3')
+const assert = require('chai').use(require('chai-as-promised')).assert;
 
 describe("HttpWrapper", () => {
     it("connect to node, get version", async () => {

--- a/test/server_helper_test.js
+++ b/test/server_helper_test.js
@@ -13,7 +13,7 @@ const gasPricePercent = 20
 contract('ServerHelper', function (accounts) {
     let minStake = 1.5e17
     let minDelay = 10
-    var serverHelper = new ServerHelper(minStake, minDelay, new HttpWrapper(web3), true)
+    var serverHelper = new ServerHelper(minStake, minDelay, new HttpWrapper(), true)
     let rhub
     let relayproc
 

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -63,7 +63,7 @@ module.exports = {
         })
 
         let res
-        let http = new HttpWrapper(web3)
+        let http = new HttpWrapper()
         let count1 = 3
         while (count1-- > 0) {
             try {


### PR DESCRIPTION
Adds a configurable timeout to all http requests done via the HTTP wrapper. 

Uses [axios](https://www.npmjs.com/package/axios) to manage http requests, instead of the web3 http provider, which has a configurable http timeout out of the box. The value is configurable, and set to 10 seconds by default in the RelayClient.

Fixes #73.