### PR TITLE
Relay client strategy for fetching relays

### DIFF
--- a/src/js/relayclient/RelayClient.js
+++ b/src/js/relayclient/RelayClient.js
@@ -46,7 +46,7 @@ class RelayClient {
         this.config = config || {};
         this.web3 = web3;
         this.httpSend = new HttpWrapper({ timeout: this.config.httpTimeout || DEFAULT_HTTP_TIMEOUT });
-        this.serverHelper = this.config.serverHelper || new ServerHelper(this.config.minStake || 0, this.config.minDelay || 0, this.httpSend, this.config.verbose)
+        this.serverHelper = this.config.serverHelper || new ServerHelper(this.httpSend, this.config);
     }
 
     createRelayRecipient(addr) {

--- a/src/js/relayclient/ServerHelper.js
+++ b/src/js/relayclient/ServerHelper.js
@@ -1,4 +1,4 @@
-
+const BN = require('web3').utils.toBN;
 
 class ActiveRelayPinger {
 
@@ -112,12 +112,12 @@ class ServerHelper {
         this.verbose = verbose
         
         this.relayFilter = relayFilter || ((relay) => (
-            (!minDelay || relay.unstakeDelay >= minDelay) &&
-            (!minStake || relay.stake >= minStake)
+            (!minDelay || BN(relay.unstakeDelay).gte(BN(minDelay))) &&
+            (!minStake || BN(relay.stake).gte(BN(minStake)))
         ));
 
         this.relayComparator = relayComparator || ((r1, r2) => (
-            r1.txFee - r2.txFee
+            BN(r1.transactionFee).cmp(BN(r2.transactionFee))
         ));
 
         this.filteredRelays = []
@@ -134,8 +134,6 @@ class ServerHelper {
             this.filteredRelays = []
         }
         this.relayHubInstance = relayHubInstance
-
-        this.relayHubAddress = this.relayHubInstance._address
     }
 
     async newActiveRelayPinger(fromBlock, gasPrice ) {
@@ -198,7 +196,8 @@ class ServerHelper {
         }
 
         this.filteredRelays = filteredRelays;
-        this.isInitialized = true
+        this.isInitialized = true;
+        return filteredRelays;
     }
 }
 

--- a/test/server_helper_test.js
+++ b/test/server_helper_test.js
@@ -1,8 +1,5 @@
-const assert = require('chai')
-  .use(require('chai-as-promised'))
-  .assert;
-
-/* global web3 contract it assert before after artifacts */
+/* global web3 contract it before after artifacts describe beforeEach afterEach */
+const assert = require('chai').use(require('chai-as-promised')).assert;
 const ServerHelper = require('../src/js/relayclient/ServerHelper');
 const HttpWrapper = require('../src/js/relayclient/HttpWrapper');
 const testutils = require('./testutils')
@@ -141,13 +138,13 @@ contract('ServerHelper', function (accounts) {
             { relay: '7', transactionFee: 1e7 },
         ].map(relay => ({ 
             event: 'RelayAdded', 
-            returnValues: { 
+            returnValues: Object.assign({}, { 
                 transactionFee: 1e10, 
                 relayUrl: `url-${relay.relay}`, 
                 stake: 2e17, 
-                unstakeDelay: 100, 
-                ...relay 
-            }}));
+                unstakeDelay: 100
+            }, relay)
+        }));
 
         beforeEach('set mock relay hub', function () {
             this.originalRelayHub = serverHelper.relayHubInstance;

--- a/test/server_helper_test.js
+++ b/test/server_helper_test.js
@@ -1,3 +1,7 @@
+const assert = require('chai')
+  .use(require('chai-as-promised'))
+  .assert;
+
 /* global web3 contract it assert before after artifacts */
 const ServerHelper = require('../src/js/relayclient/ServerHelper');
 const HttpWrapper = require('../src/js/relayclient/HttpWrapper');
@@ -13,7 +17,8 @@ const gasPricePercent = 20
 contract('ServerHelper', function (accounts) {
     let minStake = 1.5e17
     let minDelay = 10
-    var serverHelper = new ServerHelper(new HttpWrapper(), { minStake, minDelay, verbose: true })
+    let httpWrapper = new HttpWrapper()
+    let serverHelper = new ServerHelper(httpWrapper, { minStake, minDelay, verbose: false })
     let rhub
     let relayproc
 
@@ -29,83 +34,151 @@ contract('ServerHelper', function (accounts) {
         await testutils.stopRelay(relayproc)
     })
 
-    // Note: a real relay server is not registered in this test.
-    it("should discover a relay from the relay contract", async function () {
-        // unstake delay too low
-        await register_new_relay(rhub, 2e17, 2, 20, "https://abcd.com", accounts[7], accounts[0]);
-        // unregistered
-        await register_new_relay(rhub, 2e17, 20, 2, "https://abcd.com", accounts[2], accounts[0]);
-        // stake too low
-        await register_new_relay(rhub, 1e17, 20, 20, "https://abcd.com", accounts[3], accounts[0]);
+    describe('with running relay hub', function () {
+        // Note: a real relay server is not registered in this context
+        before('registering relays', async function () {
+            // unstake delay too low
+            await register_new_relay(rhub, 2e17, 2, 20, "https://abcd1.com", accounts[7], accounts[0]);
+            // unregistered
+            await register_new_relay(rhub, 2e17, 20, 2, "https://abcd2.com", accounts[2], accounts[0]);
+            // stake too low
+            await register_new_relay(rhub, 1e17, 20, 20, "https://abcd3.com", accounts[3], accounts[0]);
 
-        // Added, removed, added again - go figure.
-        // 2 x will not ping
-        await register_new_relay(rhub, 2e17, 20, 15, "https://abcd.com", accounts[4], accounts[0]);
-        await rhub.remove_relay_by_owner(accounts[4], { from: accounts[0] });
-        await increaseTime(20 + 1);
-        await rhub.unstake(accounts[4],{ from: accounts[0] });
-        await register_new_relay(rhub, 2e17, 20, 15, "go_resolve_this_address", accounts[4], accounts[0]);
+            // Added, removed, added again - go figure.
+            // 2 x will not ping
+            await register_new_relay(rhub, 2e17, 20, 15, "https://abcd4.com", accounts[4], accounts[0]);
+            await rhub.remove_relay_by_owner(accounts[4], { from: accounts[0] });
+            await increaseTime(20 + 1);
+            await rhub.unstake(accounts[4],{ from: accounts[0] });
+            await register_new_relay(rhub, 2e17, 20, 15, "go_resolve_this_address", accounts[4], accounts[0]);
 
-        await register_new_relay(rhub, 2e17, 20, 30, "https://abcd.com", accounts[5], accounts[0]);
+            await register_new_relay(rhub, 2e17, 20, 30, "https://abcd4.com", accounts[5], accounts[0]);
 
-        await rhub.remove_relay_by_owner(accounts[2], { from: accounts[0] });
-        await increaseTime(20 + 1);
-        await rhub.unstake(accounts[2],{ from: accounts[0] });
+            await rhub.remove_relay_by_owner(accounts[2], { from: accounts[0] });
+            await increaseTime(20 + 1);
+            await rhub.unstake(accounts[2],{ from: accounts[0] });
 
-        serverHelper.setHub(rhub)
-        let pinger = await serverHelper.newActiveRelayPinger()
-        let relay = await pinger.nextRelay()
-        assert.equal(localhostOne, relay.relayUrl);
+            serverHelper.setHub(rhub);
+        });
+        
+        it("should list all relays from relay contract", async function () {
+            const relays = await serverHelper.fetchRelaysAdded();
+            assert.deepEqual(
+                relays.map(relay => relay.relayUrl), 
+                [localhostOne, 'go_resolve_this_address', 'https://abcd4.com']
+            );
+        });
+
+        it("should discover a relay from the relay contract", async function () {
+            let pinger = await serverHelper.newActiveRelayPinger()
+            let relay = await pinger.nextRelay()
+            assert.equal(localhostOne, relay.relayUrl);
+        });
     });
 
+    describe('with mock http wrapper', function () {
+        //mock for HttpWrapper: instead of sending any ping, the URL is expected to be a json. (ignoring the "getaddr" suffix)
+        // if it contains "error", then return it as error. otherwise, its the http send response.
+        class MockHttpWrapper {
+            constructor() {
+                this.pinged=0
+            }
 
-    //mock for HttpWrapper: instead of sending any ping, the URL is expected to be a json. (ignoring the "getaddr" suffix)
-    // if it contains "error", then return it as error. otherwise, its the http send response.
-    class MockHttpWrapper {
-        constructor() {
-            this.pinged=0
-        }
+            send(url, jsonRequestData, callback) {
 
-        send(url, jsonRequestData, callback) {
+                let relayInfo = JSON.parse(url.replace(/\/\w+$/,''))
 
-            let relayInfo = JSON.parse(url.replace(/\/\w+$/,''))
+                this.pinged++
 
-            this.pinged++
-
-            if (relayInfo.error) {
-                setTimeout(() => callback(new Error(url), null), 0)
-            } else {
-                setTimeout(() => callback(null, relayInfo), 0)
+                if (relayInfo.error) {
+                    setTimeout(() => callback(new Error(url), null), 0)
+                } else {
+                    setTimeout(() => callback(null, relayInfo), 0)
+                }
             }
         }
-    }
 
-    it( "ActiveRelayPinger should keep trying find a relay after 6 broken (high gas, not ready) relays", async function() {
+        it( "ActiveRelayPinger should keep trying find a relay after 6 broken (high gas, not ready) relays", async function() {
 
-        let mockRelays = [
-            { relayUrl:"url1", error: "failed relay1", stake:1, unstakeDelay:1 },
-            { relayUrl:"url2", Ready:false, stake:1, unstakeDelay:1 },
-            { relayUrl:"url3", error: "failed relay1", stake:1, unstakeDelay:1 },
-            { relayUrl:"url4", MinGasPrice: 1e20, Ready:true, stake:1, unstakeDelay:1 },
-            { relayUrl:"url5", MinGasPrice: 1, Ready:true, stake:1, unstakeDelay:1 },
-            { relayUrl:"url6", Ready:false, stake:1, unstakeDelay:1 },
-            { relayUrl:"url7", MinGasPrice: 1, Ready:true, stake:1, unstakeDelay:1 },
-        ]
+            let mockRelays = [
+                { relayUrl:"url1", error: "failed relay1", stake:1, unstakeDelay:1 },
+                { relayUrl:"url2", Ready:false, stake:1, unstakeDelay:1 },
+                { relayUrl:"url3", error: "failed relay1", stake:1, unstakeDelay:1 },
+                { relayUrl:"url4", MinGasPrice: 1e20, Ready:true, stake:1, unstakeDelay:1 },
+                { relayUrl:"url5", MinGasPrice: 1, Ready:true, stake:1, unstakeDelay:1 },
+                { relayUrl:"url6", Ready:false, stake:1, unstakeDelay:1 },
+                { relayUrl:"url7", MinGasPrice: 1, Ready:true, stake:1, unstakeDelay:1 },
+            ]
 
 
-        mockRelays.forEach(r => r.relayUrl = JSON.stringify(r))
+            mockRelays.forEach(r => r.relayUrl = JSON.stringify(r))
 
-        let mockHttpWrapper = new MockHttpWrapper( mockRelays )
+            let mockHttpWrapper = new MockHttpWrapper( mockRelays )
 
-        let pinger = new serverHelper.ActiveRelayPinger(mockRelays, mockHttpWrapper, 100)
+            let pinger = new serverHelper.ActiveRelayPinger(mockRelays, mockHttpWrapper, 100)
 
-        //should skip the bad relays, 3 at a time, and reach relay 5
-        let r = await pinger.nextRelay()
-        //validate its "url5" that got returned (the other were rejected)
-        assert.equal("url5", JSON.parse(r.relayUrl).relayUrl )
-        //make sure we totally tried exactly 6 relays (we ping in triplets)
-        assert.equal(6, mockHttpWrapper.pinged )
+            //should skip the bad relays, 3 at a time, and reach relay 5
+            let r = await pinger.nextRelay()
+            //validate its "url5" that got returned (the other were rejected)
+            assert.equal("url5", JSON.parse(r.relayUrl).relayUrl )
+            //make sure we totally tried exactly 6 relays (we ping in triplets)
+            assert.equal(6, mockHttpWrapper.pinged )
 
-    })
+        })
+    });
 
+    describe('with mock relay hub', function () {
+        // let minStake = 1.5e17
+        // let minDelay = 10
+    
+        const mockRelayAddedEvents = [
+            { relay: '1' },
+            { relay: '2' },
+            { relay: '3' },
+            { relay: '4', unstakeDelay: 5 },
+            { relay: '5', stake: 1e17, transactionFee: 1e5 },
+            { relay: '6', stake: 3e17, transactionFee: 1e9 },
+            { relay: '7', transactionFee: 1e7 },
+        ].map(relay => ({ 
+            event: 'RelayAdded', 
+            returnValues: { 
+                transactionFee: 1e10, 
+                relayUrl: `url-${relay.relay}`, 
+                stake: 2e17, 
+                unstakeDelay: 100, 
+                ...relay 
+            }}));
+
+        beforeEach('set mock relay hub', function () {
+            this.originalRelayHub = serverHelper.relayHubInstance;
+            this.mockRelayHub = { getPastEvents: () => mockRelayAddedEvents };
+            serverHelper.setHub(this.mockRelayHub);
+        });
+
+        afterEach('restore original relay hub', function () {
+            serverHelper.setHub(this.originalRelayHub);
+        });
+
+        it("should use default strategy for filtering and sorting relays", async function() {
+            const relays = await serverHelper.fetchRelaysAdded();
+            assert.deepEqual(relays.map(r => r.address), ['7', '6', '1', '2', '3']);
+        });
+
+        it("should not filter relays if minimum values not set", async function() {
+            const customServerHelper = new ServerHelper(httpWrapper, { });
+            customServerHelper.setHub(this.mockRelayHub);
+            const relays = await customServerHelper.fetchRelaysAdded();
+            assert.deepEqual(relays.map(r => r.address), ['5', '7', '6', '1', '2', '3', '4']);
+        });
+
+        it("should use custom strategy for filtering and sorting relays", async function() {
+            const customServerHelper = new ServerHelper(httpWrapper, {
+                relayFilter: (relay) => (relay.address > '4'),
+                relayComparator: (r1, r2) => (r2.stake - r1.stake)
+            });
+            customServerHelper.setHub(this.mockRelayHub);
+            const relays = await customServerHelper.fetchRelaysAdded();
+            assert.deepEqual(relays.map(r => r.address), ['6', '7', '5']);
+        });
+    });
 })

--- a/test/server_helper_test.js
+++ b/test/server_helper_test.js
@@ -13,7 +13,7 @@ const gasPricePercent = 20
 contract('ServerHelper', function (accounts) {
     let minStake = 1.5e17
     let minDelay = 10
-    var serverHelper = new ServerHelper(minStake, minDelay, new HttpWrapper(), true)
+    var serverHelper = new ServerHelper(new HttpWrapper(), { minStake, minDelay, verbose: true })
     let rhub
     let relayproc
 


### PR DESCRIPTION
Adds options to the relay client to specify custom functions to filter and sort relays when listing them from the relay hub. Defaults to filtering by stake and delay (if specified) and filtering by transaction fee.

This PR also fixes the existing sorting by transaction fee, which was using a non-existing `txFee` field instead of `transactionFee`, and uses bignumber for all comparisons (since web3 beta.37 returns all numeric values as strings).

Fixes #79.