### PR TITLE
Store pending transactions in relay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,11 @@
 /node_modules/
 /server/src/github.com/ethereum/go-ethereum/
 /metacoin/
-tabookey-gasless-0.1.0.tgz
+tabookey-gasless-*.tgz
 /.vscode/settings.json
 /.idea/
 /server/pkg/darwin_amd64/
+/server/pkg/linux_amd64/
+/server/bin/
 /serverdock/version
 /secret_mnemonic

--- a/package-lock.json
+++ b/package-lock.json
@@ -3689,9 +3689,9 @@
       "dev": true
     },
     "ganache-cli": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.2.5.tgz",
-      "integrity": "sha512-E4SP8QNeuc2N/ojFoCK+08OYHX8yrtGeFtipZmJPPTQ6U8Hmq3JcbXZDxQfChPQUY5mtbRSwptJa4EtiQyJjAQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.4.3.tgz",
+      "integrity": "sha512-3G+CK4ojipDvxQHlpX8PjqaOMRWVcaLZZSW97Bv7fdcPTXQwkji2yY5CY6J12Atiub4M4aJc0va+q3HXeerbIA==",
       "dev": true,
       "requires": {
         "bn.js": "4.11.8",
@@ -3701,32 +3701,27 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "bundled": true,
           "dev": true
         },
         "bn.js": {
           "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "bundled": true,
           "dev": true
         },
         "buffer-from": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-          "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+          "bundled": true,
           "dev": true
         },
         "camelcase": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "bundled": true,
           "dev": true
         },
         "cliui": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "string-width": "^2.1.1",
@@ -3736,14 +3731,12 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "bundled": true,
           "dev": true
         },
         "cross-spawn": {
           "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
@@ -3753,14 +3746,12 @@
         },
         "decamelize": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "bundled": true,
           "dev": true
         },
         "execa": {
           "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cross-spawn": "^5.0.1",
@@ -3774,8 +3765,7 @@
         },
         "find-up": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "locate-path": "^2.0.0"
@@ -3783,44 +3773,37 @@
         },
         "get-caller-file": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+          "bundled": true,
           "dev": true
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "bundled": true,
           "dev": true
         },
         "invert-kv": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+          "bundled": true,
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "bundled": true,
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+          "bundled": true,
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+          "bundled": true,
           "dev": true
         },
         "lcid": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "invert-kv": "^1.0.0"
@@ -3828,8 +3811,7 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "p-locate": "^2.0.0",
@@ -3838,8 +3820,7 @@
         },
         "lru-cache": {
           "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.4.tgz",
-          "integrity": "sha512-EPstzZ23znHUVLKj+lcXO1KvZkrlw+ZirdwvOmnAnA/1PB4ggyXJ77LRkCqkff+ShQ+cqoxCxLQOh4cKITO5iA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
@@ -3848,8 +3829,7 @@
         },
         "mem": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "mimic-fn": "^1.0.0"
@@ -3857,14 +3837,12 @@
         },
         "mimic-fn": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+          "bundled": true,
           "dev": true
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "path-key": "^2.0.0"
@@ -3872,14 +3850,12 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "bundled": true,
           "dev": true
         },
         "os-locale": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "execa": "^0.7.0",
@@ -3889,14 +3865,12 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+          "bundled": true,
           "dev": true
         },
         "p-limit": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "p-try": "^1.0.0"
@@ -3904,8 +3878,7 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "p-limit": "^1.1.0"
@@ -3913,50 +3886,42 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "bundled": true,
           "dev": true
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "bundled": true,
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "bundled": true,
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+          "bundled": true,
           "dev": true
         },
         "require-directory": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+          "bundled": true,
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "bundled": true,
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "bundled": true,
           "dev": true
         },
         "shebang-command": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
@@ -3964,26 +3929,22 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+          "bundled": true,
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "bundled": true,
           "dev": true
         },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "bundled": true,
           "dev": true
         },
         "source-map-support": {
           "version": "0.5.9",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-          "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
@@ -3992,8 +3953,7 @@
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -4002,8 +3962,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
@@ -4011,14 +3970,12 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+          "bundled": true,
           "dev": true
         },
         "which": {
           "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -4026,14 +3983,12 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "bundled": true,
           "dev": true
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "string-width": "^1.0.1",
@@ -4042,14 +3997,12 @@
           "dependencies": {
             "ansi-regex": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "bundled": true,
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
@@ -4057,8 +4010,7 @@
             },
             "string-width": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -4068,8 +4020,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -4079,20 +4030,17 @@
         },
         "y18n": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "bundled": true,
           "dev": true
         },
         "yallist": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+          "bundled": true,
           "dev": true
         },
         "yargs": {
           "version": "11.1.0",
-          "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-          "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cliui": "^4.0.0",
@@ -4111,8 +4059,7 @@
         },
         "yargs-parser": {
           "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "camelcase": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "eslint": "^5.12.1",
-    "ganache-cli": "^6.2.5",
+    "ganache-cli": "^6.4.3",
     "http-server": "^0.11.1",
     "promisify": "0.0.3",
     "run-with-testrpc": "^0.3.0",

--- a/scripts/fundrelay.js
+++ b/scripts/fundrelay.js
@@ -16,7 +16,7 @@ async function fundrelay(hubaddr, relayaddr, fromaddr, fund, stake, unstake_dela
         console.log( "already has a stake of "+(curstake/1e18)+" eth. NOT adding more")
     } else {
         console.log( "staking ",stake)
-        console.log( await rhub.methods.stake(relayaddr, unstake_delay).send({value: stake, from:fromaddr}))
+        console.log( await rhub.methods.stake(relayaddr, unstake_delay).send({value: stake, from:fromaddr, gas: 1e6}))
     }
 
     let balance = await web3.eth.getBalance(relayaddr)
@@ -24,7 +24,7 @@ async function fundrelay(hubaddr, relayaddr, fromaddr, fund, stake, unstake_dela
         console.log( "already has a balance of "+(stake/1e18)+" eth. NOT adding more")
     } else {
         ret = await new Promise((resolve,reject)=> {
-            web3.eth.sendTransaction({from: fromaddr, to: relayaddr,value:fund}, (e, r) => {
+            web3.eth.sendTransaction({from: fromaddr, to: relayaddr,value:fund, gas: 1e6}, (e, r) => {
                 if (e) reject(e)
                 else resolve(r)
             })

--- a/scripts/ganache-fund.js
+++ b/scripts/ganache-fund.js
@@ -5,20 +5,30 @@ Web3 = require( 'web3')
 
 url = process.env.URL
 ethvalue=process.argv[2]
-destaddr = process.argv[3]
+destaddrs = process.argv[3]
 acct=process.argv[4] || 0 
-if ( ! ethvalue ) {
+if (!ethvalue || !destaddrs) {
 	console.log( "usage:", process.argv[1], " {ethvalue} {destaddr} [fromacct] " )
 	process.exit(1)
 }
 
+let value = ethvalue * 1e18
 web3 = new Web3(new Web3.providers.HttpProvider(url||'http://localhost:8545'))
-
-web3.eth.sendTransaction({from: web3.eth.accounts[acct], to: destaddr, value: ethvalue*1e18 }, (e,r)=>{
-	if (e) {
-		console.log( "Failed to transfer: ",e)
-	} else {
-		console.log( "Successfully funded" )
+web3.eth.getAccounts().then((accounts) => {
+	let from = accounts[acct];
+	for (let to of destaddrs.split(',')) {
+		web3.eth.getBalance(to).then(res => {
+			if (res >= value) {
+				console.log("Account is already funded", to)
+				return
+			}
+			web3.eth.sendTransaction({from, to, value }, (e,r)=>{
+				if (e) {
+					console.log("Failed to transfer", e)
+				} else {
+					console.log("Successfully funded", to)
+				}
+			})
+		})
 	}
 })
-

--- a/scripts/ganache-fund.js
+++ b/scripts/ganache-fund.js
@@ -18,7 +18,7 @@ web3.eth.getAccounts().then((accounts) => {
 	let from = accounts[acct];
 	for (let to of destaddrs.split(',')) {
 		web3.eth.getBalance(to).then(res => {
-			if (res >= value) {
+			if (web3.utils.toBN(res).cmp(web3.utils.toBN(value)) > 0) {
 				console.log("Account is already funded", to)
 				return
 			}

--- a/scripts/run-ganache
+++ b/scripts/run-ganache
@@ -1,0 +1,34 @@
+# Exit script as soon as a command fails.
+set -o errexit
+
+ganache_port=${1:-8544}
+
+cleanup() {
+  # Kill the ganache instance that we started (if we started one and if it's still running).
+  if [ -n "$ganache_pid" ] && ps -p $ganache_pid > /dev/null; then
+    kill -9 $ganache_pid
+  fi
+}
+
+ganache_running() {
+  nc -z localhost "$ganache_port"
+}
+
+start_ganache() {
+  node_modules/.bin/ganache-cli --networkId 4447 -g 1000 -p $ganache_port -d > /dev/null &
+  ganache_pid=$!
+  echo $ganache_pid
+
+  while ! ganache_running; do
+    sleep 0.1
+  done
+}
+
+if ganache_running; then
+  echo "Using existing ganache instance" >&2
+else
+  echo "Starting our own ganache instance" >&2
+  start_ganache
+fi
+
+echo `node_modules/.bin/ganache-cli --version` >&2

--- a/server/Makefile
+++ b/server/Makefile
@@ -21,7 +21,7 @@ $(server_exe): $(GEN_FILE) $(GEN_FILE_REC) go-get $(ETHFILE) $() $(shell find . 
 	strip $(server_exe)
 
 go-get: $(GEN_FILE) $(ETHFILE)
-	go get -v code.cloudfoundry.org/clock
+	go get -v code.cloudfoundry.org/clock github.com/syndtr/goleveldb/leveldb
 
 $(ETHFILE): Makefile
 	@echo "Downloading the ethereum library. Might take a few minutes."

--- a/server/Makefile
+++ b/server/Makefile
@@ -9,6 +9,7 @@ server: $(server_exe)
 ETHDIR=./src/github.com/ethereum/go-ethereum
 ETHFILE=${ETHDIR}/Makefile
 ETHREPO="https://github.com/ethereum/go-ethereum.git"
+ETHVERSION=v1.8.21
 
 GEN_FILE=$(buildpath)/src/gen/librelay/relay_hub_sol.go 
 GEN_FILE_REC=$(buildpath)/src/gen/samplerec/sample_rec_sol.go 
@@ -24,7 +25,7 @@ go-get: $(GEN_FILE) $(ETHFILE)
 $(ETHFILE): Makefile
 	@echo "Downloading the ethereum library.  Might take a few minutes."
 	@if [ ! -d ${ETHDIR} ]; then \
-	  git clone ${ETHREPO} --depth=1 --branch=v1.8.21 ${ETHDIR} ;\
+	  git clone ${ETHREPO} --depth=1 --branch=${ETHVERSION} ${ETHDIR} ;\
 	  go get -v -d ./...;\
 	fi 
 	touch $(ETHFILE)

--- a/server/Makefile
+++ b/server/Makefile
@@ -14,13 +14,14 @@ ETHVERSION=v1.8.21
 GEN_FILE=$(buildpath)/src/gen/librelay/relay_hub_sol.go 
 GEN_FILE_REC=$(buildpath)/src/gen/samplerec/sample_rec_sol.go 
 
-$(server_exe): $(GEN_FILE) $(GEN_FILE_REC) $(ETHFILE) $(shell find . -maxdepth 3 -name '*.go') Makefile
+$(server_exe): $(GEN_FILE) $(GEN_FILE_REC) go-get $(ETHFILE) $() $(shell find . -maxdepth 3 -name '*.go') Makefile
 	echo "Using GOPATH=$(GOPATH)"
 	mkdir -p $(buildpath)/bin
 	go build -o $(server_exe) src/RelayHttpServer.go src/utils.go
 	strip $(server_exe)
 
-go-get: $(GEN_FILE) $(ETHFILE) 
+go-get: $(GEN_FILE) $(ETHFILE)
+	go get -v code.cloudfoundry.org/clock
 
 $(ETHFILE): Makefile
 	@echo "Downloading the ethereum library.  Might take a few minutes."

--- a/server/Makefile
+++ b/server/Makefile
@@ -24,7 +24,7 @@ go-get: $(GEN_FILE) $(ETHFILE)
 	go get -v code.cloudfoundry.org/clock
 
 $(ETHFILE): Makefile
-	@echo "Downloading the ethereum library.  Might take a few minutes."
+	@echo "Downloading the ethereum library. Might take a few minutes."
 	@if [ ! -d ${ETHDIR} ]; then \
 	  git clone ${ETHREPO} --depth=1 --branch=${ETHVERSION} ${ETHDIR} ;\
 	  go get -v -d ./...;\
@@ -42,4 +42,4 @@ $(GEN_FILE_REC): ../contracts/SampleRecipient.sol
 	abigen --solc ../scripts/solc-abigen-wrapper.sh --sol $< --pkg samplerec  --out $@
 
 test: server
-	go test -v -count=1 librelay
+	@scripts/test.sh

--- a/server/scripts/test.sh
+++ b/server/scripts/test.sh
@@ -11,7 +11,6 @@ onexit() {
 }
 
 cd .. && \
-  ./scripts/run-ganache ${TESTPORT} > ganache.pid && \
-  URL=http://localhost:${TESTPORT} ./scripts/ganache-fund.js 2.337 ${TESTADDRS}
+  ./scripts/run-ganache ${TESTPORT} > ganache.pid
 
 go test -v -count=1 librelay

--- a/server/scripts/test.sh
+++ b/server/scripts/test.sh
@@ -14,3 +14,4 @@ cd .. && \
   ./scripts/run-ganache ${TESTPORT} > ganache.pid
 
 go test -v -count=1 librelay
+go test -v -count=1 librelay/txstore

--- a/server/scripts/test.sh
+++ b/server/scripts/test.sh
@@ -1,0 +1,17 @@
+TESTPORT=8543
+TESTADDRS=0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1,0xFFcf8FDEE72ac11b5c542428B35EEF5769C409f0,0x22d491Bde2303f2f43325b2108D26f1eAbA1e32b
+
+trap onexit EXIT
+
+onexit() {
+  if [ -f "ganache.pid" ]; then 
+    echo "Stopping ganache"
+    kill `cat ganache.pid` && rm ganache.pid 
+  fi
+}
+
+cd .. && \
+  ./scripts/run-ganache ${TESTPORT} > ganache.pid && \
+  URL=http://localhost:${TESTPORT} ./scripts/ganache-fund.js 2.337 ${TESTADDRS}
+
+go test -v -count=1 librelay

--- a/server/src/RelayHttpServer.go
+++ b/server/src/RelayHttpServer.go
@@ -226,7 +226,7 @@ func configRelay(relayParams librelay.RelayParams) {
 		relayParams.RelayHubAddress, relayParams.StakeAmount,
 		relayParams.GasLimit, relayParams.DefaultGasPrice, relayParams.GasPricePercent,
 		privateKey, relayParams.UnstakeDelay, relayParams.RegistrationBlockRate, relayParams.EthereumNodeURL,
-		client)
+		client, librelay.NewMemoryTxStore(nil), nil)
 	if err != nil {
 		log.Println("Could not create Relay Server", err)
 		return

--- a/server/src/RelayHttpServer.go
+++ b/server/src/RelayHttpServer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"io/ioutil"
 	"librelay"
+	"librelay/txstore"
 	"log"
 	"math/big"
 	"net/http"
@@ -226,7 +227,7 @@ func configRelay(relayParams librelay.RelayParams) {
 		relayParams.RelayHubAddress, relayParams.StakeAmount,
 		relayParams.GasLimit, relayParams.DefaultGasPrice, relayParams.GasPricePercent,
 		privateKey, relayParams.UnstakeDelay, relayParams.RegistrationBlockRate, relayParams.EthereumNodeURL,
-		client, librelay.NewMemoryTxStore(nil), nil)
+		client, txstore.NewMemoryTxStore(nil), nil)
 	if err != nil {
 		log.Println("Could not create Relay Server", err)
 		return

--- a/server/src/librelay/relay_server.go
+++ b/server/src/librelay/relay_server.go
@@ -104,6 +104,8 @@ type IRelay interface {
 
 	UpdateUnconfirmedTransactions() (newTx *types.Transaction, err error)
 
+	Close() (err error)
+
 	sendRegisterTransaction() (tx *types.Transaction, err error)
 
 	awaitTransactionMined(tx *types.Transaction) (err error)
@@ -147,7 +149,10 @@ type RelayServer struct {
 	clock                 clock.Clock
 }
 
-type RelayParams RelayServer
+type RelayParams struct {
+	RelayServer
+	DBFile string
+}
 
 func NewEthClient(EthereumNodeURL string, defaultGasPrice int64) (IClient, error) {
 	client := &TbkClient{DefaultGasPrice: defaultGasPrice}
@@ -784,4 +789,8 @@ func (relay *RelayServer) replayUnconfirmedTxs(client *ethclient.Client) {
 		}
 	}
 	log.Println("replayUnconfirmedTxs end")
+}
+
+func (relay *RelayServer) Close() (err error) {
+	return relay.TxStore.Close()
 }

--- a/server/src/librelay/relay_server.go
+++ b/server/src/librelay/relay_server.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"gen/librelay"
+	"librelay/txstore"
 	"log"
 	"math/big"
 	"strings"
@@ -141,7 +142,7 @@ type RelayServer struct {
 	gasPrice              *big.Int // set dynamically as suggestedGasPrice*(GasPricePercent+100)/100
 	Client                IClient
 	ChainID               *big.Int
-	TxStore               ITxStore
+	TxStore               txstore.ITxStore
 	rhub                  *librelay.RelayHub
 	clock                 clock.Clock
 }
@@ -170,7 +171,7 @@ func NewRelayServer(
 	RegistrationBlockRate uint64,
 	EthereumNodeURL string,
 	Client IClient,
-	TxStore ITxStore,
+	TxStore txstore.ITxStore,
 	clk clock.Clock) (*RelayServer, error) {
 
 	rhub, err := librelay.NewRelayHub(RelayHubAddress, Client)

--- a/server/src/librelay/relay_server_test.go
+++ b/server/src/librelay/relay_server_test.go
@@ -4,9 +4,17 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/hex"
+	"flag"
 	"fmt"
 	"gen/librelay"
 	"gen/samplerec"
+	"log"
+	"math/big"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
@@ -16,12 +24,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
-	"log"
-	"math/big"
-	"os"
-	"strings"
-	"testing"
-	"time"
 )
 
 type FakeClient struct {
@@ -131,12 +133,13 @@ func NewRelay(relayHubAddress common.Address) {
 	unstakeDelay := big.NewInt(0)
 	registrationBlockRate := uint64(5)
 	ethereumNodeUrl := ""
+	txStore := NewMemoryTxStore()
 	var err error
 	relay.relayServer, err = NewRelayServer(
 		common.Address{}, fee, url, port,
 		relayHubAddress, stakeAmount, gasLimit, defaultGasPrice,
 		gasPricePercent, relayKey1, unstakeDelay, registrationBlockRate,
-		ethereumNodeUrl, sim)
+		ethereumNodeUrl, sim, txStore)
 	if err != nil {
 		log.Fatalln("Relay was not created", err)
 	}
@@ -222,6 +225,7 @@ func TestMain(m *testing.M) {
 	}
 	log.Println("To.balance: ", to_balance)
 
+	flag.Parse()
 	exitStatus := m.Run()
 	defer os.Exit(exitStatus)
 

--- a/server/src/librelay/relay_server_test.go
+++ b/server/src/librelay/relay_server_test.go
@@ -15,6 +15,8 @@ import (
 	"testing"
 	"time"
 
+	"code.cloudfoundry.org/clock/fakeclock"
+
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
@@ -103,6 +105,7 @@ var relayKey1 *ecdsa.PrivateKey
 var gaslessKey2 *ecdsa.PrivateKey
 var ownerKey3 *ecdsa.PrivateKey
 var rhub *librelay.RelayHub
+var clk *fakeclock.FakeClock
 
 var sampleRecipient common.Address
 var rhaddr common.Address
@@ -133,13 +136,14 @@ func NewRelay(relayHubAddress common.Address) {
 	unstakeDelay := big.NewInt(0)
 	registrationBlockRate := uint64(5)
 	ethereumNodeUrl := ""
-	txStore := NewMemoryTxStore()
+	clk = fakeclock.NewFakeClock(time.Now())
+	txStore := NewMemoryTxStore(clk)
 	var err error
 	relay.relayServer, err = NewRelayServer(
 		common.Address{}, fee, url, port,
 		relayHubAddress, stakeAmount, gasLimit, defaultGasPrice,
 		gasPricePercent, relayKey1, unstakeDelay, registrationBlockRate,
-		ethereumNodeUrl, sim, txStore)
+		ethereumNodeUrl, sim, txStore, clk)
 	if err != nil {
 		log.Fatalln("Relay was not created", err)
 	}

--- a/server/src/librelay/test/utils.go
+++ b/server/src/librelay/test/utils.go
@@ -1,0 +1,19 @@
+package test
+
+import (
+	"testing"
+)
+
+func ErrFail(err error, t *testing.T) {
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+}
+
+func ErrFailWithDesc(err error, t *testing.T, desc string) {
+	if err != nil {
+		t.Error(desc, err)
+		t.FailNow()
+	}
+}

--- a/server/src/librelay/tx_store.go
+++ b/server/src/librelay/tx_store.go
@@ -1,0 +1,88 @@
+package librelay
+
+import (
+	"container/list"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+type TimestampedTransaction struct {
+	*types.Transaction
+	Timestamp int64
+}
+
+type ITxStore interface {
+	GetFirstTransaction() (tx *TimestampedTransaction, err error)
+	SaveTransaction(tx *types.Transaction) (err error)
+	UpdateTransactionByNonce(tx *types.Transaction) (err error)
+	RemoveTransactionsUptoNonce(nonce uint64) (err error)
+}
+
+type MemoryTxStore struct {
+	transactions *list.List
+	mutex        *sync.Mutex
+}
+
+func NewMemoryTxStore() *MemoryTxStore {
+	return &MemoryTxStore{
+		transactions: list.New(),
+		mutex:        &sync.Mutex{},
+	}
+}
+
+// GetFirstTransaction returns transaction with lowest nonce
+func (store *MemoryTxStore) GetFirstTransaction() (tx *TimestampedTransaction, err error) {
+	front := store.transactions.Front()
+	if front == nil {
+		return nil, nil
+	}
+	return front.Value.(*TimestampedTransaction), nil
+}
+
+// SaveTransaction dates and stores transaction sorted by ascending nonce
+func (store *MemoryTxStore) SaveTransaction(tx *types.Transaction) (err error) {
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+
+	timedtx := &TimestampedTransaction{tx, time.Now().Unix()}
+	for e := store.transactions.Front(); e != nil; e = e.Next() {
+		if e.Value.(*TimestampedTransaction).Nonce() > tx.Nonce() {
+			store.transactions.InsertBefore(timedtx, e)
+			return
+		}
+	}
+
+	store.transactions.PushBack(timedtx)
+	return
+}
+
+// UpdateTransactionByNonce updates a transaction given its nonce, returns error if tx with same nonce does not exist
+func (store *MemoryTxStore) UpdateTransactionByNonce(tx *types.Transaction) (err error) {
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+
+	timedtx := &TimestampedTransaction{tx, time.Now().Unix()}
+	for e := store.transactions.Front(); e != nil; e = e.Next() {
+		if e.Value.(*TimestampedTransaction).Nonce() == tx.Nonce() {
+			e.Value = timedtx
+			return nil
+		}
+	}
+
+	return fmt.Errorf("Could not find transaction with nonce %d", tx.Nonce())
+}
+
+// RemoveTransactionsUptoNonce removes all transactions with nonce values up to the specified value inclusive
+func (store *MemoryTxStore) RemoveTransactionsUptoNonce(nonce uint64) (err error) {
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+
+	for e := store.transactions.Front(); e != nil && e.Value.(*TimestampedTransaction).Nonce() <= nonce; e = store.transactions.Front() {
+		store.transactions.Remove(e)
+	}
+
+	return
+}

--- a/server/src/librelay/tx_store.go
+++ b/server/src/librelay/tx_store.go
@@ -20,6 +20,7 @@ type ITxStore interface {
 	SaveTransaction(tx *types.Transaction) (err error)
 	UpdateTransactionByNonce(tx *types.Transaction) (err error)
 	RemoveTransactionsUptoNonce(nonce uint64) (err error)
+	Clear() (err error)
 }
 
 type MemoryTxStore struct {
@@ -91,5 +92,14 @@ func (store *MemoryTxStore) RemoveTransactionsUptoNonce(nonce uint64) (err error
 		store.transactions.Remove(e)
 	}
 
+	return
+}
+
+// Clear removes all transactions stored
+func (store *MemoryTxStore) Clear() (err error) {
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+
+	store.transactions = list.New()
 	return
 }

--- a/server/src/librelay/tx_store.go
+++ b/server/src/librelay/tx_store.go
@@ -19,7 +19,7 @@ type ITxStore interface {
 	GetFirstTransaction() (tx *TimestampedTransaction, err error)
 	SaveTransaction(tx *types.Transaction) (err error)
 	UpdateTransactionByNonce(tx *types.Transaction) (err error)
-	RemoveTransactionsUptoNonce(nonce uint64) (err error)
+	RemoveTransactionsLessThanNonce(nonce uint64) (err error)
 	Clear() (err error)
 }
 
@@ -83,12 +83,12 @@ func (store *MemoryTxStore) UpdateTransactionByNonce(tx *types.Transaction) (err
 	return fmt.Errorf("Could not find transaction with nonce %d", tx.Nonce())
 }
 
-// RemoveTransactionsUptoNonce removes all transactions with nonce values up to the specified value inclusive
-func (store *MemoryTxStore) RemoveTransactionsUptoNonce(nonce uint64) (err error) {
+// RemoveTransactionsLessThanNonce removes all transactions with nonce values up to the specified value inclusive
+func (store *MemoryTxStore) RemoveTransactionsLessThanNonce(nonce uint64) (err error) {
 	store.mutex.Lock()
 	defer store.mutex.Unlock()
 
-	for e := store.transactions.Front(); e != nil && e.Value.(*TimestampedTransaction).Nonce() <= nonce; e = store.transactions.Front() {
+	for e := store.transactions.Front(); e != nil && e.Value.(*TimestampedTransaction).Nonce() < nonce; e = store.transactions.Front() {
 		store.transactions.Remove(e)
 	}
 

--- a/server/src/librelay/txstore/leveldb_store.go
+++ b/server/src/librelay/txstore/leveldb_store.go
@@ -1,0 +1,173 @@
+package txstore
+
+import (
+	"encoding/binary"
+	"fmt"
+	"sync"
+
+	"code.cloudfoundry.org/clock"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+
+	"github.com/syndtr/goleveldb/leveldb"
+)
+
+type LevelDbTxStore struct {
+	*leveldb.DB
+	clock clock.Clock
+	mutex *sync.Mutex
+}
+
+func (tx *TimestampedTransaction) Encode() ([]byte, error) {
+	bytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(bytes, uint64(tx.Timestamp))
+	txBytes, err := rlp.EncodeToBytes(tx.Transaction)
+	if err != nil {
+		return nil, err
+	}
+	bytes = append(bytes, txBytes...)
+	return bytes, nil
+}
+
+func DecodeTimestampedTransaction(bytes []byte) (*TimestampedTransaction, error) {
+	var tx types.Transaction
+	err := rlp.DecodeBytes(bytes[8:], &tx)
+	if err != nil {
+		return nil, err
+	}
+
+	timestamp := int64(binary.BigEndian.Uint64(bytes[:8]))
+	timedtx := TimestampedTransaction{&tx, timestamp}
+	return &timedtx, nil
+}
+
+func NewLevelDbTxStore(file string, clk clock.Clock) (store *LevelDbTxStore, err error) {
+	if clk == nil {
+		clk = clock.NewClock()
+	}
+
+	db, err := leveldb.OpenFile(file, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &LevelDbTxStore{db, clk, &sync.Mutex{}}, nil
+}
+
+// ListTransactions returns all transactions on the store, useful for testing
+func (store *LevelDbTxStore) ListTransactions() (txs []*TimestampedTransaction, err error) {
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+
+	txs = make([]*TimestampedTransaction, 0, 20)
+	iter := store.NewIterator(nil, nil)
+	defer iter.Release()
+	for iter.Next() {
+		value := iter.Value()
+		tx, err := DecodeTimestampedTransaction(value)
+		if err != nil {
+			return nil, err
+		}
+		txs = append(txs, tx)
+	}
+
+	return
+}
+
+// GetFirstTransaction returns transaction with lowest nonce
+func (store *LevelDbTxStore) GetFirstTransaction() (tx *TimestampedTransaction, err error) {
+	iter := store.NewIterator(nil, nil)
+	defer iter.Release()
+
+	if iter.Next() {
+		value := iter.Value()
+		tx, err := DecodeTimestampedTransaction(value)
+		if err != nil {
+			return nil, err
+		}
+		return tx, nil
+	}
+	return nil, nil
+}
+
+// SaveTransaction dates and stores transaction sorted by ascending nonce
+func (store *LevelDbTxStore) SaveTransaction(tx *types.Transaction) (err error) {
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+
+	timedtx := &TimestampedTransaction{tx, store.clock.Now().Unix()}
+	txbytes, err := timedtx.Encode()
+	if err != nil {
+		return err
+	}
+
+	key := make([]byte, 8)
+	binary.BigEndian.PutUint64(key, tx.Nonce())
+	err = store.Put(key, txbytes, nil)
+	if err != nil {
+		return err
+	}
+
+	return
+}
+
+// UpdateTransactionByNonce updates a transaction given its nonce, returns error if tx with same nonce does not exist
+func (store *LevelDbTxStore) UpdateTransactionByNonce(tx *types.Transaction) (err error) {
+	key := make([]byte, 8)
+	binary.BigEndian.PutUint64(key, tx.Nonce())
+
+	_, err = store.Get(key, nil)
+	if err == leveldb.ErrNotFound {
+		return fmt.Errorf("Could not find transaction with nonce %d", tx.Nonce())
+	} else if err != nil {
+		return err
+	}
+
+	return store.SaveTransaction(tx)
+}
+
+// RemoveTransactionsLessThanNonce removes all transactions with nonce values up to the specified value inclusive
+func (store *LevelDbTxStore) RemoveTransactionsLessThanNonce(nonce uint64) (err error) {
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+
+	batch := new(leveldb.Batch)
+	iter := store.NewIterator(nil, nil)
+
+	for iter.Next() {
+		key := iter.Key()
+		value := iter.Value()
+		tx, err := DecodeTimestampedTransaction(value)
+		if err != nil {
+			iter.Release()
+			return err
+		}
+
+		if tx.Nonce() < nonce {
+			batch.Delete(key)
+		} else {
+			break
+		}
+	}
+
+	iter.Release()
+	return store.Write(batch, nil)
+}
+
+// Clear removes all transactions stored
+func (store *LevelDbTxStore) Clear() (err error) {
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+
+	batch := new(leveldb.Batch)
+	iter := store.NewIterator(nil, nil)
+
+	for iter.Next() {
+		key := iter.Key()
+		batch.Delete(key)
+	}
+
+	iter.Release()
+	return store.Write(batch, nil)
+}

--- a/server/src/librelay/txstore/memory_store.go
+++ b/server/src/librelay/txstore/memory_store.go
@@ -101,3 +101,7 @@ func (store *MemoryTxStore) Clear() (err error) {
 	store.transactions = list.New()
 	return
 }
+
+func (store *MemoryTxStore) Close() (err error) {
+	return nil
+}

--- a/server/src/librelay/txstore/memory_store.go
+++ b/server/src/librelay/txstore/memory_store.go
@@ -1,4 +1,4 @@
-package librelay
+package txstore
 
 import (
 	"container/list"
@@ -9,19 +9,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 )
-
-type TimestampedTransaction struct {
-	*types.Transaction
-	Timestamp int64
-}
-
-type ITxStore interface {
-	GetFirstTransaction() (tx *TimestampedTransaction, err error)
-	SaveTransaction(tx *types.Transaction) (err error)
-	UpdateTransactionByNonce(tx *types.Transaction) (err error)
-	RemoveTransactionsLessThanNonce(nonce uint64) (err error)
-	Clear() (err error)
-}
 
 type MemoryTxStore struct {
 	transactions *list.List
@@ -39,6 +26,17 @@ func NewMemoryTxStore(clk clock.Clock) *MemoryTxStore {
 		mutex:        &sync.Mutex{},
 		clock:        clk,
 	}
+}
+
+// ListTransactions returns all transactions on the store, useful for testing
+func (store *MemoryTxStore) ListTransactions() (txs []*TimestampedTransaction, err error) {
+	txs = make([]*TimestampedTransaction, 0, 20)
+
+	for e := store.transactions.Front(); e != nil; e = e.Next() {
+		txs = append(txs, e.Value.(*TimestampedTransaction))
+	}
+
+	return
 }
 
 // GetFirstTransaction returns transaction with lowest nonce

--- a/server/src/librelay/txstore/tx_store.go
+++ b/server/src/librelay/txstore/tx_store.go
@@ -16,4 +16,5 @@ type ITxStore interface {
 	UpdateTransactionByNonce(tx *types.Transaction) (err error)
 	RemoveTransactionsLessThanNonce(nonce uint64) (err error)
 	Clear() (err error)
+	Close() (err error)
 }

--- a/server/src/librelay/txstore/tx_store.go
+++ b/server/src/librelay/txstore/tx_store.go
@@ -1,0 +1,19 @@
+package txstore
+
+import (
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+type TimestampedTransaction struct {
+	*types.Transaction
+	Timestamp int64
+}
+
+type ITxStore interface {
+	ListTransactions() (txs []*TimestampedTransaction, err error)
+	GetFirstTransaction() (tx *TimestampedTransaction, err error)
+	SaveTransaction(tx *types.Transaction) (err error)
+	UpdateTransactionByNonce(tx *types.Transaction) (err error)
+	RemoveTransactionsLessThanNonce(nonce uint64) (err error)
+	Clear() (err error)
+}

--- a/server/src/librelay/txstore/tx_store_test.go
+++ b/server/src/librelay/txstore/tx_store_test.go
@@ -1,0 +1,112 @@
+package txstore
+
+import (
+	"fmt"
+	"math/big"
+	"math/rand"
+	"testing"
+	"time"
+
+	"librelay/test"
+
+	"code.cloudfoundry.org/clock/fakeclock"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+func newTx(nonce uint64) (tx *types.Transaction) {
+	address, err := common.NewMixedcaseAddressFromString("ffcf8fdee72ac11b5c542428b35eef5769c409f0")
+	if err != nil {
+		fmt.Println("BOO", err)
+	}
+	gas := uint64(rand.Int63n(1e9))
+	return types.NewTransaction(nonce, address.Address(), big.NewInt(10), gas, big.NewInt(2000), nil)
+}
+
+func testStore(t *testing.T, store ITxStore, clk *fakeclock.FakeClock) {
+	t.Run("GetFirstTransaction returns nil", func(t *testing.T) {
+		tx, err := store.GetFirstTransaction()
+		if tx != nil || err != nil {
+			t.Fail()
+		}
+	})
+
+	t.Run("Clear deletes all txs", func(t *testing.T) {
+		test.ErrFail(store.SaveTransaction(newTx(2)), t)
+		test.ErrFail(store.Clear(), t)
+		tx, err := store.GetFirstTransaction()
+		if tx != nil || err != nil {
+			t.Fail()
+		}
+	})
+
+	t.Run("SaveTransaction stores current time", func(t *testing.T) {
+		test.ErrFail(store.SaveTransaction(newTx(2)), t)
+		tx, _ := store.GetFirstTransaction()
+		if tx.Nonce() != 2 {
+			t.Fail()
+		}
+		if tx.Timestamp < clk.Now().Unix()-1 || tx.Timestamp > clk.Now().Unix() {
+			t.Errorf("Wrong timestamp on saved tx: was %v but current time is %v", tx.Timestamp, clk.Now().Unix())
+		}
+	})
+
+	t.Run("SaveTransaction stores txs in order by nonce", func(t *testing.T) {
+		store.Clear()
+		test.ErrFail(store.SaveTransaction(newTx(4)), t)
+		test.ErrFail(store.SaveTransaction(newTx(3)), t)
+		test.ErrFail(store.SaveTransaction(newTx(5)), t)
+		tx, _ := store.GetFirstTransaction()
+		if tx.Nonce() != 3 {
+			t.Fail()
+		}
+	})
+
+	t.Run("UpdateTransactionByNonce updates the tx", func(t *testing.T) {
+		store.Clear()
+		updatedTx := newTx(4)
+		test.ErrFail(store.SaveTransaction(newTx(4)), t)
+		test.ErrFail(store.SaveTransaction(newTx(3)), t)
+		test.ErrFail(store.SaveTransaction(newTx(5)), t)
+		test.ErrFail(store.UpdateTransactionByNonce(updatedTx), t)
+
+		txs, err := store.ListTransactions()
+		test.ErrFail(err, t)
+
+		if txs[1].Hash() != updatedTx.Hash() {
+			t.Fail()
+		}
+	})
+
+	t.Run("UpdateTransactionByNonce fails if tx is not present", func(t *testing.T) {
+		store.Clear()
+		test.ErrFail(store.SaveTransaction(newTx(3)), t)
+		err := store.UpdateTransactionByNonce(newTx(4))
+		if err == nil {
+			t.Fail()
+		}
+	})
+
+	t.Run("RemoveTransactionsLessThanNonce removes transactions strictly less than parameter", func(t *testing.T) {
+		store.Clear()
+		test.ErrFail(store.SaveTransaction(newTx(4)), t)
+		test.ErrFail(store.SaveTransaction(newTx(3)), t)
+		test.ErrFail(store.SaveTransaction(newTx(7)), t)
+		test.ErrFail(store.SaveTransaction(newTx(5)), t)
+		test.ErrFail(store.RemoveTransactionsLessThanNonce(5), t)
+
+		txs, err := store.ListTransactions()
+		test.ErrFail(err, t)
+
+		if len(txs) != 2 || txs[0].Nonce() != 5 || txs[1].Nonce() != 7 {
+			t.Errorf("Transactions left after removal: %v", txs)
+		}
+	})
+}
+
+func TestMemoryStore(t *testing.T) {
+	clk := fakeclock.NewFakeClock(time.Now())
+	store := NewMemoryTxStore(clk)
+	testStore(t, store, clk)
+}


### PR DESCRIPTION
Adds a new `TxStore` component that stores all unconfirmed transactions, with two implementations: an in-memory one and a LevelDB-backed one. Transactions are stored ordered by increasing nonce. Whenever a transactions is sent, it is added to the store.

RelayServer has now a `UpdateUnconfirmedTransactions` method for updating the transactions on the store. This process removes all transactions from the store that have been confirmed (ie mined at least 12 blocks ago). If the transaction with the lowest nonce is pending (ie not mined) after 5 minutes, it is resent with an increased gas price (25% extra, with a max cap), and its timestamp is reset.

This method is now invoked every minute from the RelayHTTPServer.

Fixes #77