### PR TITLE
Fixing flickering test

### DIFF
--- a/src/js/relayclient/utils.js
+++ b/src/js/relayclient/utils.js
@@ -85,9 +85,14 @@ module.exports = {
         return sig;
     },
 
-    getTransactionSignatureWithKey: function(privKey, hash) {
-        let msg = Buffer.concat([Buffer.from("\x19Ethereum Signed Message:\n32"), Buffer.from(removeHexPrefix(hash), "hex")])
-        let signed = web3Utils.sha3("0x"+msg.toString('hex') );
+    getTransactionSignatureWithKey: function(privKey, hash, withPrefix=true) {
+        let signed
+        if (withPrefix){
+            let msg = Buffer.concat([Buffer.from("\x19Ethereum Signed Message:\n32"), Buffer.from(removeHexPrefix(hash), "hex")])
+            signed = web3Utils.sha3("0x"+msg.toString('hex') )
+        }
+        else
+            signed = hash
         let keyHex = "0x" + Buffer.from(privKey).toString('hex')
         const sig_ = EthCrypto.sign(keyHex, signed)
         let signature = ethUtils.fromRpcSig(sig_);

--- a/test/relay_hub_test.js
+++ b/test/relay_hub_test.js
@@ -468,8 +468,9 @@ contract("RelayHub", function (accounts) {
             let snitching_account_initial_balance = await web3.eth.getBalance(snitching_account);
 
             let unsignedillegalTransactionEncoded = encodeRLP(illegalTransaction)
-            illegalTransaction.sign(privKey);
-            let sig = signatureHex(illegalTransaction);
+            let hash = "0x" + illegalTransaction.hash(false).toString('hex')
+            let sig = utils.getTransactionSignatureWithKey(privKey,hash,false)
+            assert.equal(sig.length, 132);
             let res = await rhub.penalize_illegal_transaction(unsignedillegalTransactionEncoded, sig, {
                 from: snitching_account,
                 gasPrice: gasPricePenalize,


### PR DESCRIPTION
ethereumjs-tx returns tx signature fields v,r,s as buffers, and
truncates them if they have leading zeroes, which is a problem when
doing ecrecover on-chain.