### PR TITLE
RelayHub singleton

### DIFF
--- a/contracts/RelayHub.sol
+++ b/contracts/RelayHub.sol
@@ -169,7 +169,7 @@ contract RelayHub is RelayHubApi {
         return handle_accept_relay_call(to,accept_relayed_call_raw_tx);
     }
 
-    function handle_accept_relay_call(RelayRecipient to, bytes memory accept_relayed_call_raw_tx) private view returns (uint32){
+    function handle_accept_relay_call(RelayRecipientApi to, bytes memory accept_relayed_call_raw_tx) private view returns (uint32){
         bool success;
         uint32 accept = uint32(CanRelayStatus.AcceptRelayedCallUnkownError);
         assembly {

--- a/contracts/RelayHub.sol
+++ b/contracts/RelayHub.sol
@@ -1,7 +1,7 @@
 pragma solidity >=0.4.0 <0.6.0;
 
 import "./RelayHubApi.sol";
-import "./RelayRecipient.sol";
+import "./RelayRecipientApi.sol";
 import "./GsnUtils.sol";
 import "./RLPReader.sol";
 import "@0x/contracts-utils/contracts/src/LibBytes.sol";
@@ -74,7 +74,7 @@ contract RelayHub is RelayHubApi {
     /**
      * withdraw funds.
      * caller is either a relay owner, withdrawing collected transaction fees.
-     * or a RelayRecipient contract, withdrawing its deposit.
+     * or a RelayRecipientApi contract, withdrawing its deposit.
      * note that while everyone can `depositFor()` a contract, only
      * the contract itself can withdraw its funds.
      */
@@ -156,7 +156,7 @@ contract RelayHub is RelayHubApi {
 	// for contract-specific checks.
 	// returns "0" if the relay is valid. other values represent errors.
 	// values 1..10 are reserved for can_relay. other values can be used by accept_relayed_call of target contracts.
-    function can_relay(address relay, address from, RelayRecipient to, bytes memory encoded_function, uint transaction_fee, uint gas_price, uint gas_limit, uint nonce, bytes memory approval) public view returns(uint32) {
+    function can_relay(address relay, address from, RelayRecipientApi to, bytes memory encoded_function, uint transaction_fee, uint gas_price, uint gas_limit, uint nonce, bytes memory approval) public view returns(uint32) {
         bytes memory packed = abi.encodePacked("rlx:", from, to, encoded_function, transaction_fee, gas_price, gas_limit, nonce, address(this));
         bytes32 hashed_message = keccak256(abi.encodePacked(packed, relay));
         bytes32 signed_message = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hashed_message));
@@ -187,7 +187,7 @@ contract RelayHub is RelayHubApi {
     /**
      * relay a transaction.
      * @param from the client originating the request.
-     * @param to the target RelayRecipient contract.
+     * @param to the target RelayRecipientApi contract.
      * @param encoded_function the function call to relay.
      * @param transaction_fee fee (%) the relay takes over actual gas cost.
      * @param gas_price gas price the client is willing to pay
@@ -201,7 +201,7 @@ contract RelayHub is RelayHubApi {
         require(relays[msg.sender].state == State.REGISTERED, "Unknown relay");  // Must be from a known relay
         require(gas_price <= tx.gasprice, "Invalid gas price");      // Relay must use the gas price set by the signer
 
-        uint32 can_relay_result = can_relay(msg.sender, from, RelayRecipient(to), encoded_function, transaction_fee, gas_price, gas_limit, nonce, approval);
+        uint32 can_relay_result = can_relay(msg.sender, from, RelayRecipientApi(to), encoded_function, transaction_fee, gas_price, gas_limit, nonce, approval);
         if (can_relay_result != 0) {
             emit TransactionRelayed(msg.sender, from, to, keccak256(encoded_function), uint(RelayCallStatus.CanRelayFailed), 0);
             return;
@@ -241,7 +241,7 @@ contract RelayHub is RelayHubApi {
         bool success_post;
         uint balance_before = balances[to];
         (success, ) = to.call.gas(gas_limit)(transaction); // transaction must end with @from at this point
-        transaction = abi.encodeWithSelector(RelayRecipient(to).post_relayed_call.selector, relay_addr, from, encoded_function, success, (gas_overhead+initial_gas-gasleft()), transaction_fee);
+        transaction = abi.encodeWithSelector(RelayRecipientApi(to).post_relayed_call.selector, relay_addr, from, encoded_function, success, (gas_overhead+initial_gas-gasleft()), transaction_fee);
         (success_post, ) = to.call.gas((gas_overhead+initial_gas-gasleft()))(transaction);
         require(success_post, "post_relayed_call reverted - reverting the relayed transaction");
         require(balance_before <= balances[to], "Moving funds during relayed transaction disallowed");
@@ -264,7 +264,7 @@ contract RelayHub is RelayHubApi {
     }
 
     function penalize_repeated_nonce(bytes memory unsigned_tx1, bytes memory sig1 ,bytes memory unsigned_tx2, bytes memory sig2) public {
-        // Can be called by anyone.  
+        // Can be called by anyone.
         // If a relay attacked the system by signing multiple transactions with the same nonce (so only one is accepted), anyone can grab both transactions from the blockchain and submit them here.
         // Check whether unsigned_tx1 != unsigned_tx2, that both are signed by the same address, and that unsigned_tx1.nonce == unsigned_tx2.nonce.  If all conditions are met, relay is considered an "offending relay".
         // The offending relay will be unregistered immediately, its stake will be forfeited and given to the address who reported it (msg.sender), thus incentivizing anyone to report offending relays.

--- a/contracts/RelayHubApi.sol
+++ b/contracts/RelayHubApi.sol
@@ -28,12 +28,15 @@ contract  RelayHubApi {
 
     function get_nonce(address from) view external returns (uint);
     function relay(address from, address to, bytes memory encoded_function, uint transaction_fee, uint gas_price, uint gas_limit, uint nonce, bytes memory approval) public;
-    
+
     function depositFor(address target) public payable;
     function balanceOf(address target) external view returns (uint256);
 
     function stake(address relayaddr, uint unstake_delay) external payable;
     function stakeOf(address relayaddr) external view returns (uint256);
     function ownerOf(address relayaddr) external view returns (address);
+
+    function unstake(address _relay) public;
+    function withdraw(uint amount) public;
 }
 

--- a/contracts/RelayRecipient.sol
+++ b/contracts/RelayRecipient.sol
@@ -30,7 +30,7 @@ contract RelayRecipient is RelayRecipientApi {
         require(relay_hub == RelayHub(0), "init_relay_hub: rhub already set");
         set_relay_hub(_rhub);
     }
-    
+
     function set_relay_hub(RelayHub _rhub) internal {
         // Normally called just once, during init_relay_hub.
         // Left as a separate internal function, in case a contract wishes to have its own update mechanism for RelayHub.
@@ -79,32 +79,5 @@ contract RelayRecipient is RelayRecipientApi {
         }
         return orig_msg_data;
     }
-
-    /*
-	 * Contract must inherit and re-implement this method.
-	 *  @return "0" if the the contract is willing to accept the charges from this sender, for this function call.
-	 *  	any other value is a failure. actual value is for diagnostics only.
-	 *** Note :values below 10 are reserved by can_relay
-	 *  @param relay the relay that attempts to relay this function call.
-	 * 			the contract may restrict some encoded functions to specific known relays.
-	 *  @param from the sender (signer) of this function call.
-	 *  @param encoded_function the encoded function call (without any ethereum signature).
-	 * 			the contract may check the method-id for valid methods
-	 *  @param gas_price - the gas price for this transaction
-	 *  @param transaction_fee - the relay compensation (in %) for this transaction
-	 *  @param approval - first 65 bytes are checked by the RelayHub and reserved for the sender's signature, and the rest is
-     *           available for dapps in their specific use-cases
-	 */
-    function accept_relayed_call(address relay, address from, bytes memory encoded_function, uint gas_price, uint transaction_fee, bytes memory approval) public view returns(uint32);
-
-    /**
-     * This method is called after the relayed call.
-     * It may be used to record the transaction (e.g. charge the caller by some contract logic) for this call.
-     * the method is given all parameters of accept_relayed_call, and also the success/failure status and actual used gas.
-     * - success - true if the relayed call succeeded, false if it reverted
-     * - used_gas - gas used up to this point. Note that gas calculation (for the purpose of compensation
-     *   to the relay) is done after this method returns.
-     */
-    function post_relayed_call(address relay, address from, bytes memory encoded_function, bool success, uint used_gas, uint transaction_fee ) public;
 }
 

--- a/contracts/RelayRecipient.sol
+++ b/contracts/RelayRecipient.sol
@@ -3,44 +3,44 @@ pragma solidity >=0.4.0 <0.6.0;
 // Contract that implements the relay recipient protocol.  Inherited by Gatekeeper, or any other relay recipient.
 //
 // The recipient contract is responsible to:
-// * pass a trusted RelayHub singleton to the constructor.
+// * pass a trusted RelayHubApi singleton to the constructor.
 // * Implement accept_relayed_call, which acts as a whitelist/blacklist of senders.  It is advised that the recipient's owner will be able to update that list to remove abusers.
 // * In every function that cares about the sender, use "address sender = get_sender()" instead of msg.sender.  It'll return msg.sender for non-relayed transactions, or the real sender in case of relayed transactions.
 
 import "./RelayRecipientApi.sol";
-import "./RelayHub.sol";
+import "./RelayHubApi.sol";
 import "@0x/contracts-utils/contracts/src/LibBytes.sol";
 
 contract RelayRecipient is RelayRecipientApi {
 
-    RelayHub private relay_hub; // The RelayHub singleton which is allowed to call us
+    RelayHubApi private relay_hub; // The RelayHubApi singleton which is allowed to call us
 
 	function get_hub_addr() public view returns (address) {
 		return address(relay_hub);
 	}
 
     /**
-     * initialize the relayhub.
-     * contracts usually call this method from the constructor (using a constract RelayHub, or receiving
+     * initialize the RelayHubApi.
+     * contracts usually call this method from the constructor (using a constract RelayHubApi, or receiving
      * one in the constructor)
-     * This method might also be called by the owner, in order to use a new RelayHub - since the RelayHub
+     * This method might also be called by the owner, in order to use a new RelayHubApi - since the RelayHubApi
      * itself is not an upgradable contract.
      */
-    function init_relay_hub(RelayHub _rhub) internal {
-        require(relay_hub == RelayHub(0), "init_relay_hub: rhub already set");
+    function init_relay_hub(RelayHubApi _rhub) internal {
+        require(relay_hub == RelayHubApi(0), "init_relay_hub: rhub already set");
         set_relay_hub(_rhub);
     }
 
-    function set_relay_hub(RelayHub _rhub) internal {
+    function set_relay_hub(RelayHubApi _rhub) internal {
         // Normally called just once, during init_relay_hub.
-        // Left as a separate internal function, in case a contract wishes to have its own update mechanism for RelayHub.
+        // Left as a separate internal function, in case a contract wishes to have its own update mechanism for RelayHubApi.
         relay_hub = _rhub;
 
-        //attempt a read method, just to validate the relay is a valid RelayHub contract.
+        //attempt a read method, just to validate the relay is a valid RelayHubApi contract.
         get_recipient_balance();
     }
 
-    function get_relay_hub() internal view returns (RelayHub) {
+    function get_relay_hub() internal view returns (RelayHubApi) {
         return relay_hub;
     }
 
@@ -55,7 +55,7 @@ contract RelayRecipient is RelayRecipientApi {
     function get_sender_from_data(address orig_sender, bytes memory msg_data) public view returns(address) {
         address sender = orig_sender;
         if (orig_sender == get_hub_addr() ) {
-            // At this point we know that the sender is a trusted RelayHub, so we trust that the last bytes of msg.data are the verified sender address.
+            // At this point we know that the sender is a trusted RelayHubApi, so we trust that the last bytes of msg.data are the verified sender address.
             // extract sender address from the end of msg.data
             sender = LibBytes.readAddress(msg_data, msg_data.length - 20);
         }
@@ -69,7 +69,7 @@ contract RelayRecipient is RelayRecipientApi {
     function get_message_data() public view returns(bytes memory) {
         bytes memory orig_msg_data = msg.data;
         if (msg.sender == get_hub_addr()) {
-            // At this point we know that the sender is a trusted RelayHub, so we trust that the last bytes of msg.data are the verified sender address.
+            // At this point we know that the sender is a trusted RelayHubApi, so we trust that the last bytes of msg.data are the verified sender address.
             // extract original message data from the start of msg.data
             orig_msg_data = new bytes(msg.data.length - 20);
             for (uint256 i = 0; i < orig_msg_data.length; i++)

--- a/contracts/RelayRecipientApi.sol
+++ b/contracts/RelayRecipientApi.sol
@@ -13,4 +13,30 @@ contract RelayRecipientApi {
      * before making any.
      */
     function get_recipient_balance() public view returns (uint);
+
+    /*
+     *  @return "0" if the the contract is willing to accept the charges from this sender, for this function call.
+     *      any other value is a failure. actual value is for diagnostics only.
+     *** Note :values below 10 are reserved by can_relay
+     *  @param relay the relay that attempts to relay this function call.
+     *          the contract may restrict some encoded functions to specific known relays.
+     *  @param from the sender (signer) of this function call.
+     *  @param encoded_function the encoded function call (without any ethereum signature).
+     *          the contract may check the method-id for valid methods
+     *  @param gas_price - the gas price for this transaction
+     *  @param transaction_fee - the relay compensation (in %) for this transaction
+     *  @param approval - first 65 bytes are checked by the RelayHub and reserved for the sender's signature, and the rest is
+     *           available for dapps in their specific use-cases
+     */
+    function accept_relayed_call(address relay, address from, bytes memory encoded_function, uint gas_price, uint transaction_fee, bytes memory approval) public view returns (uint32);
+
+    /**
+     * This method is called after the relayed call.
+     * It may be used to record the transaction (e.g. charge the caller by some contract logic) for this call.
+     * the method is given all parameters of accept_relayed_call, and also the success/failure status and actual used gas.
+     * - success - true if the relayed call succeeded, false if it reverted
+     * - used_gas - gas used up to this point. Note that gas calculation (for the purpose of compensation
+     *   to the relay) is done after this method returns.
+     */
+    function post_relayed_call(address relay, address from, bytes memory encoded_function, bool success, uint used_gas, uint transaction_fee) public;
 }

--- a/contracts/SampleRecipient.sol
+++ b/contracts/SampleRecipient.sol
@@ -1,7 +1,7 @@
 pragma solidity >=0.4.0 <0.6.0;
 
 import "./GsnUtils.sol";
-import "./RelayHub.sol";
+import "./RelayHubApi.sol";
 import "./RelayRecipient.sol";
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
@@ -9,7 +9,7 @@ contract SampleRecipient is RelayRecipient, Ownable {
 
     mapping (address => bool) public relays_whitelist;
 
-    constructor(RelayHub rhub) public {
+    constructor(RelayHubApi rhub) public {
         init_relay_hub(rhub);
     }
 
@@ -18,7 +18,7 @@ contract SampleRecipient is RelayRecipient, Ownable {
     }
 
     function withdraw() public onlyOwner {
-        uint balance = get_relay_hub().balances(address(this));
+        uint balance = get_relay_hub().balanceOf(address(this));
         get_relay_hub().withdraw(balance);
         msg.sender.transfer(balance);
     }
@@ -53,7 +53,7 @@ contract SampleRecipient is RelayRecipient, Ownable {
         // May be protected by a user_credits map managed by a captcha-protected web app or association with a google account.
         if ( relays_whitelist[relay] ) return 0;
         if (from == blacklisted) return 11;
-        
+
         // this is an example of how the dapp can provide an offchain approval to a transaction
         if (approval.length == 65){
             // No owner signature given - proceed as usual (for existing tests)

--- a/package-lock.json
+++ b/package-lock.json
@@ -444,6 +444,116 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@resolver-engine/core": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@resolver-engine/core/-/core-0.2.1.tgz",
+      "integrity": "sha512-nsLQHmPJ77QuifqsIvqjaF5B9aHnDzJjp73Q1z6apY3e9nqYrx4Dtowhpsf7Jwftg/XzVDEMQC+OzUBNTS+S1A==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.1.0",
+        "request": "^2.85.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "@resolver-engine/fs": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@resolver-engine/fs/-/fs-0.2.1.tgz",
+      "integrity": "sha512-7kJInM1Qo2LJcKyDhuYzh9ZWd+mal/fynfL9BNjWOiTcOpX+jNfqb/UmGUqros5pceBITlWGqS4lU709yHFUbg==",
+      "dev": true,
+      "requires": {
+        "@resolver-engine/core": "^0.2.1",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "@resolver-engine/imports": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@resolver-engine/imports/-/imports-0.2.2.tgz",
+      "integrity": "sha512-u5/HUkvo8q34AA+hnxxqqXGfby5swnH0Myw91o3Sm2TETJlNKXibFGSKBavAH+wvWdBi4Z5gS2Odu0PowgVOUg==",
+      "dev": true,
+      "requires": {
+        "@resolver-engine/core": "^0.2.1",
+        "debug": "^3.1.0",
+        "hosted-git-info": "^2.6.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "@resolver-engine/imports-fs": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@resolver-engine/imports-fs/-/imports-fs-0.2.2.tgz",
+      "integrity": "sha512-gFCgMvCwyppjwq0UzIjde/WI+yDs3oatJhozG9xdjJdewwtd7LiF0T5i9lrHAUtqrQbqoFE4E+ZMRVHWpWHpKQ==",
+      "dev": true,
+      "requires": {
+        "@resolver-engine/fs": "^0.2.1",
+        "@resolver-engine/imports": "^0.2.2",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
     "@types/bn.js": {
       "version": "4.11.3",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.3.tgz",
@@ -4257,6 +4367,12 @@
       "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
       "integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ=="
     },
+    "hosted-git-info": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "dev": true
+    },
     "http-errors": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
@@ -6659,6 +6775,12 @@
         }
       }
     },
+    "solidity-parser-antlr": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.4.2.tgz",
+      "integrity": "sha512-0OKT2YKZAqPe14HN7Nbo24hjmnyUYh92UjyZG0Zz2rpQhl/w8asX8qHb+ASSXfayQaiW8g9zGIupXEE355tOQQ==",
+      "dev": true
+    },
     "source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -7496,6 +7618,64 @@
       "integrity": "sha1-S/VSQuFN7uHHGUkycJGC3v8sl8o=",
       "dev": true
     },
+    "truffle-flattener": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/truffle-flattener/-/truffle-flattener-1.3.0.tgz",
+      "integrity": "sha512-ppJ9xI0tDuvCYjQlcWwMBcOKZph5U4YpG/gChyUVDxOjUIniG5g7y9vZho2PRj1FohPPnOjg1KOAVNlk/bPZrw==",
+      "dev": true,
+      "requires": {
+        "@resolver-engine/imports-fs": "^0.2.2",
+        "find-up": "^2.1.0",
+        "mkdirp": "^0.5.1",
+        "solidity-parser-antlr": "^0.4.0",
+        "tsort": "0.0.1"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        }
+      }
+    },
     "truffle-hdwallet-provider": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/truffle-hdwallet-provider/-/truffle-hdwallet-provider-1.0.2.tgz",
@@ -7516,6 +7696,12 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+    },
+    "tsort": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tsort/-/tsort-0.0.1.tgz",
+      "integrity": "sha1-4igPXoF/i/QnVlf9D5rr1E9aJ4Y=",
+      "dev": true
     },
     "tty-browserify": {
       "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "solc": "^0.5.2",
     "truffle": "^5.0.2",
     "truffle-contract": "^4.0.2",
+    "truffle-flattener": "^1.3.0",
     "truffle-hdwallet-provider": "^1.0.1"
   },
   "files": [

--- a/scripts/singleton/compute.sh
+++ b/scripts/singleton/compute.sh
@@ -1,0 +1,25 @@
+#! /bin/bash
+
+# Exit script as soon as a command fails.
+set -o errexit
+
+solidity_version="0.5.8"
+if solc --version | grep -q "$solidity_version" ; then
+  echo "Will compile using solc v$solidity_version"
+else
+  echo "solc version v$solidity_version is required"
+  exit 1
+fi
+
+output_dir="singleton"
+
+echo "Storing artifacts in directory '$output_dir'"
+
+rm -rf "$output_dir" # Delete possible remains from previous run
+mkdir -p "$output_dir"
+npx truffle-flattener contracts/RelayHub.sol > $output_dir/RelayHub.flattened.sol
+
+solc --optimize --optimize-runs 200 --metadata-literal --combined-json abi,bin,metadata "$output_dir/RelayHub.flattened.sol" > "$output_dir/RelayHub.flattened.json"
+
+node scripts/singleton/get-deploy-data.js > "$output_dir/deploy.json"
+echo "Stored deployment data in $output_dir/deploy.json"

--- a/scripts/singleton/get-deploy-data.js
+++ b/scripts/singleton/get-deploy-data.js
@@ -1,0 +1,34 @@
+const { lstatSync, readdirSync } = require('fs')
+const { join } = require('path')
+
+const ethTx = require('ethereumjs-tx');
+const ethUtils = require('ethereumjs-util');
+
+function toHexString(buffer) {
+  return '0x' + buffer.toString('hex')
+}
+
+const bin = require(`../../singleton/RelayHub.flattened.json`)
+  .contracts['singleton/RelayHub.flattened.sol:RelayHub']
+  .bin;
+
+const tx = new ethTx({
+  nonce: 0,
+  data: '0x' + bin,
+  value: 0,
+  gasPrice: 100000000000, /// 100 gigawei
+  gasLimit: 8000000,
+  v: 27,
+  r: '0x1613161316131613161316131613161316131613161316131613161316131613',
+  s: '0x1613161316131613161316131613161316131613161316131613161316131613'
+});
+
+const deployer = tx.getSenderAddress();
+
+console.log(JSON.stringify({
+  deployer: toHexString(deployer),
+  contract: {
+    address: toHexString(ethUtils.generateAddress(deployer, ethUtils.toBuffer(0))),
+    deployTx: toHexString(tx.serialize()),
+  }
+}));


### PR DESCRIPTION
Fixes https://github.com/tabookey/tabookey-gasless/issues/93

This adds scripts in `scripts/singleton`, which generate a single contract using [truffle-flattener](https://github.com/nomiclabs/truffle-flattener), compile it, craft a transaction with a synthetic signature (0x1613161316131613...) that deploys it, and output the contract's source code, ABI, and deployment details (the transaction itself, the address that must be funded in order to execute the transaction, and the contract address).

I originally made the script generate a vanity address (e.g. one that starts with 0x1613), but that adds quite a bit of complexity, takes a long while to compute, and feels like a gimmick overall: it creates false confidence in an address that starts with that prefix, when a) it's very easy to generate another contract with that same prefix, so it alone is no guarantee and the full address should be checked, and b) there will probably be multiple versions of RelayHub out there, sharing this prefix.

I also did some minor changes to the contracts themselves: there was a circular dependency between `RelayHub` and `RelayHubRecipient` because they were importing the other contract's implementations, as opposed to the API, which was incomplete: they now depend just on the API, which has some methods that used to be in the impl (though there's some stuff missing still, but I wanted to keep this PR as small as possible).