### PR TITLE
Fixes on audit comments.

### DIFF
--- a/contracts/GsnUtils.sol
+++ b/contracts/GsnUtils.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.4.0 <0.6.0;
+pragma solidity ^0.5.5;
 
 import "@0x/contracts-utils/contracts/src/LibBytes.sol";
 

--- a/contracts/IRelayHub.sol
+++ b/contracts/IRelayHub.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.4.0 <0.6.0;
+pragma solidity ^0.5.5;
 
 contract IRelayHub {
 
@@ -36,17 +36,48 @@ contract IRelayHub {
 
     function relayCall(address from, address to, bytes memory encodedFunction, uint transactionFee, uint gasPrice, uint gasLimit, uint nonce, bytes memory approval) public;
 
+    /**
+     * deposit ether for a contract.
+     * This ether will be used to repay relay calls into this contract.
+     * Contract owner should monitor the balance of his contract, and make sure
+     * to deposit more, otherwise the contract won't be able to receive relayed calls.
+     * Unused deposited can be withdrawn with `withdraw()`
+     */
     function depositFor(address target) public payable;
 
     function balanceOf(address target) external view returns (uint256);
 
+    /**
+     * add stake for the given relay.
+     * The caller of this method is the relay owner.
+     * the value of this method is added to the current stake of this relay.
+     *
+     * @param relayaddr the relay to add stake for.
+     * @param unstakeDelay - the minimum time before the owner can unstake this relay. This number can be increased,
+     *          but neven decreased for a given relay.
+     */
     function stake(address relayaddr, uint unstakeDelay) external payable;
 
     function stakeOf(address relayaddr) external view returns (uint256);
 
     function ownerOf(address relayaddr) external view returns (address);
 
+    /**
+     * move the relay's stake (after its unstakeDelay) to the owner.
+     * must be called by the relay's owner
+     */
     function unstake(address _relay) public;
+
+    /**
+     * withdraw funds.
+     * caller is either a relay owner, withdrawing collected transaction fees.
+     * or a IRelayRecipient contract, withdrawing its deposit.
+     * note that while everyone can `depositFor()` a contract, only
+     * the contract itself can withdraw its funds.
+     *
+     * So in order to be able to withdraw its own deposited funds, a contract MUST call this method
+     * (from an owner-only method)
+     */
     function withdraw(uint amount) public;
 }
 

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.4.0 <0.6.0;
+pragma solidity ^0.5.5;
 
 contract Migrations {
   address public owner;

--- a/contracts/RLPReader.sol
+++ b/contracts/RLPReader.sol
@@ -2,7 +2,7 @@
 * Taken from https://github.com/hamdiallam/Solidity-RLP
 */
 
-pragma solidity >=0.4.0 <0.6.0;
+pragma solidity ^0.5.5;
 
 library RLPReader {
 

--- a/contracts/RelayHub.sol
+++ b/contracts/RelayHub.sol
@@ -329,7 +329,12 @@ contract RelayHub is IRelayHub {
         require(relays[addr1].stake > 0, "Unstaked relay");
         // Checking that the relay wasn't penalized yet
         require(relays[addr1].state != State.PENALIZED, "Relay already penalized");
-        // compensating the sender with the stake of the relay
+
+        // compensating the sender with HALF the stake of the relay (the other half is burned)
+        uint toBurn = SafeMath.div(relays[addr1].stake,2);
+        address(0).transfer(toBurn);
+        relays[addr1].stake = SafeMath.sub(relays[addr1].stake, toBurn);
+
         uint amount = relays[addr1].stake;
         // move ownership of relay
         relays[addr1].owner = msg.sender;

--- a/contracts/RelayHub.sol
+++ b/contracts/RelayHub.sol
@@ -142,8 +142,11 @@ contract RelayHub is IRelayHub {
 
     function removeRelayByOwner(address relay) public {
         require(relays[relay].owner == msg.sender, "not owner");
-        relays[relay].unstakeTime = relays[relay].unstakeDelay + now;
+        require(relays[relay].unstakeTime == 0, "already removed");
+
         // Start the unstake counter
+        relays[relay].unstakeTime = relays[relay].unstakeDelay + now;
+
         if (relays[relay].state != State.PENALIZED && relays[relay].state != State.REMOVED) {
             relays[relay].state = State.REMOVED;
         }

--- a/contracts/SampleRecipient.sol
+++ b/contracts/SampleRecipient.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.4.0 <0.6.0;
+pragma solidity ^0.5.5;
 
 import "./GsnUtils.sol";
 import "./IRelayHub.sol";
@@ -20,7 +20,8 @@ contract SampleRecipient is RelayRecipient, Ownable {
     bool public rejectAcceptRelayCall;
 
     constructor(IRelayHub rhub) public {
-        initRelayHub(rhub);
+
+        setRelayHub(rhub);
     }
 
     function deposit() public payable {

--- a/contracts/TestRecipientUtils.sol
+++ b/contracts/TestRecipientUtils.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.4.0 <0.6.0;
+pragma solidity ^0.5.5;
 
 import './GsnUtils.sol';
 import './RelayHub.sol';

--- a/samples/contracts/KnownUsersRecipient.sol
+++ b/samples/contracts/KnownUsersRecipient.sol
@@ -29,7 +29,7 @@ contract KnownUsersRecipient is RelayRecipient {
      * @param _rhub - the relay hub we're connected to.
      */
     constructor(RelayHub _rhub, address[] _initialAdmins) public {
-		initRelayHub(_rhub);
+		setRelayHub(_rhub);
         for ( uint i=0; i< _initialAdmins.length; i++ ) {
             admins[_initialAdmins[i]] = true;
         }

--- a/samples/contracts/TokenRecipient.sol
+++ b/samples/contracts/TokenRecipient.sol
@@ -27,7 +27,7 @@ contract TokenRecipient is RelayRecipient {
      * @param _txPrice - amount of tokens to take for each request.
      */
     constructor(RelayHub _rhub, address _tokenHolder, ERC20Interface _token, uint _txPrice) public {
-		initRelayHub(_rhub);
+		setRelayHub(_rhub);
         mytoken  = _token;
         txPrice = _txPrice;
         tokenHolder = _tokenHolder;

--- a/test/relay_hub_test.js
+++ b/test/relay_hub_test.js
@@ -491,7 +491,7 @@ contract("RelayHub", function (accounts) {
         })
 
         let balance_of_acc7 = await web3.eth.getBalance(snitching_account);
-        let expected_balance_after_penalize = new Big(snitching_account_initial_balance).add(stake[0]).sub(res.receipt.gasUsed * gasPricePenalize).sub(res2.receipt.gasUsed * gasPricePenalize)
+        let expected_balance_after_penalize = new Big(snitching_account_initial_balance).add(stake[0]/2).sub(res.receipt.gasUsed * gasPricePenalize).sub(res2.receipt.gasUsed * gasPricePenalize)
         assert.equal(expected_balance_after_penalize, balance_of_acc7);
     }
 


### PR DESCRIPTION
following Zepelin's audit added some fixes.

fixed pragma solidity
removed abstract methods from RelayRecipient (as they duplicate IRelayRecipient's)
added documentation of main methods.
cleaned up comments

removed initRelayHub() - to signify setRelayHub should be used (and support updated relay)