### PR TITLE
Internal libraries

### DIFF
--- a/contracts/RLPReader.sol
+++ b/contracts/RLPReader.sol
@@ -27,7 +27,7 @@ library RLPReader {
     * @return tuple (nonce,gasPrice,gasLimit,to,value,data)
     */
 
-    function decodeTransaction(bytes memory rawTransaction) public pure returns (uint, uint, uint, address, uint, bytes memory){
+    function decodeTransaction(bytes memory rawTransaction) internal pure returns (uint, uint, uint, address, uint, bytes memory){
         RLPReader.RLPItem[] memory values = rawTransaction.toRlpItem().toList(); // must convert to an rlpItem first!
         return (values[0].toUint(), values[1].toUint(), values[2].toUint(), values[3].toAddress(), values[4].toUint(), values[5].toBytes());
     }

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -4,11 +4,7 @@ var SampleRecipient = artifacts.require("./SampleRecipient.sol");
 var RLPReader= artifacts.require("./RLPReader.sol");
 
 module.exports = function(deployer) {
-	deployer.deploy(RLPReader);
-	deployer.link(RLPReader, RelayHub);
 	deployer.deploy(RelayHub).then(function() {
 		return deployer.deploy(SampleRecipient, RelayHub.address);
 	});
-	deployer.link(RelayHub, RelayRecipient);
-	deployer.link(RelayHub, SampleRecipient);
 };


### PR DESCRIPTION
This changes `RLPReader` so that it is no longer an external library (that needs to be linked), but an internal one that is inlined. This is necessary in order to achieve #93.