### PR TITLE
Invalid error codes in acceptRelayedCall

### DIFF
--- a/contracts/IRelayHub.sol
+++ b/contracts/IRelayHub.sol
@@ -17,7 +17,8 @@ contract IRelayHub {
         OK,                         // All checks passed, the call can be relayed
         WrongSignature,             // The transaction to relay is not signed by requested sender
         WrongNonce,                 // The provided nonce has already been used by the sender
-        AcceptRelayedCallReverted   // The recipient rejected this call via acceptRelayedCall
+        AcceptRelayedCallReverted,  // The recipient rejected this call via acceptRelayedCall
+        InvalidRecipientStatusCode  // The recipient returned an invalid (reserved) status code
     }
 
     event Staked(address indexed relay, uint256 stake);

--- a/contracts/RelayHub.sol
+++ b/contracts/RelayHub.sol
@@ -201,8 +201,15 @@ contract RelayHub is IRelayHub {
         if (!success) {
             return uint256(PreconditionCheck.AcceptRelayedCallReverted);
         } else {
-            // This can be either PreconditionCheck.OK, or a value outside of the enum range.
-            return abi.decode(returndata, (uint256));
+            uint256 accept = abi.decode(returndata, (uint256));
+
+            // This can be either PreconditionCheck.OK or a custom error code
+            if ((accept == 0) || (accept > 10)) {
+                return accept;
+            } else {
+                // Error codes [1-10] are reserved to RelayHub
+                return uint256(PreconditionCheck.InvalidRecipientStatusCode);
+            }
         }
     }
 

--- a/contracts/SampleRecipient.sol
+++ b/contracts/SampleRecipient.sol
@@ -22,6 +22,8 @@ contract SampleRecipient is RelayRecipient, Ownable {
 
     bool public rejectAcceptRelayCall;
 
+    bool public returnInvalidErrorCode;
+
     constructor(IRelayHub rhub) public {
         setRelayHub(rhub);
     }
@@ -42,16 +44,20 @@ contract SampleRecipient is RelayRecipient, Ownable {
         emit Reverting("if you see this revert failed...");
     }
 
-    function setWithdrawDuringPreRelayedCall(bool val) public{
+    function setWithdrawDuringPreRelayedCall(bool val) public {
         withdrawDuringPreRelayedCall = val;
     }
 
-    function setWithdrawDuringRelayedCall(bool val) public{
+    function setWithdrawDuringRelayedCall(bool val) public {
         withdrawDuringRelayedCall = val;
     }
 
-    function setWithdrawDuringPostRelayedCall(bool val) public{
+    function setWithdrawDuringPostRelayedCall(bool val) public {
         withdrawDuringPostRelayedCall = val;
+    }
+
+    function setReturnInvalidErrorCode(bool val) public {
+        returnInvalidErrorCode = val;
     }
 
     function setOverspendAcceptGas(bool val) public{
@@ -106,6 +112,8 @@ contract SampleRecipient is RelayRecipient, Ownable {
             bytes memory ret = new bytes(32);
             (success,ret) = address(this).staticcall(abi.encodeWithSelector(this.infiniteLoop.selector));
         }
+
+        if ( returnInvalidErrorCode ) return 10;
 
         if ( relaysWhitelist[relay] ) return 0;
         if (from == blacklisted) return 11;


### PR DESCRIPTION
This PR adds a check to assert that `acceptRelayedCall` doesn't return a reserved error code, and emits a new code when this happens.