### PR TITLE
Add test for a relayed method with no parameters

### DIFF
--- a/contracts/SampleRecipient.sol
+++ b/contracts/SampleRecipient.sol
@@ -74,6 +74,10 @@ contract SampleRecipient is RelayRecipient, Ownable {
         emit SampleRecipientEmitted(message, getSender(), msg.sender, tx.origin);
     }
 
+    function emitMessageNoParams() public {
+        emit SampleRecipientEmitted("Method with no parameters", getSender(), msg.sender, tx.origin);
+    }
+
     function setRelay(address relay, bool on) public {
         relaysWhitelist[relay] = on;
     }


### PR DESCRIPTION
This proved to be a special case for some solidity precompiles (it breaks the abi.decode, for instance).
This will prevent similar bugs in the future.