### PR TITLE
Upgrade to solc-0.5.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs: # a collection of steps
   build: # runs not using Workflows must have a `build` job as entry point
     working_directory: ~/gls # directory where steps will run
     docker: # run the steps with Docker
-      - image: tabookey/eth-tools:solc-5.5b # solc5.5, NO truffle/ganache (npm-install'ed locally) # solc-5.5b: Adding netcat
+      - image: tabookey/eth-tools:solc-0.5.10
 
     steps: # a collection of executable commands
       - checkout # special step to check out source code to working directory

--- a/contracts/RelayHub.sol
+++ b/contracts/RelayHub.sol
@@ -191,38 +191,18 @@ contract RelayHub is IRelayHub {
             return uint256(PreconditionCheck.WrongNonce);
         }
 
-        bytes memory rawTx = abi.encodeWithSelector(to.acceptRelayedCall.selector,
-            relay, from, encodedFunction, gasPrice, transactionFee, approval);
+        bytes memory encodedTx = abi.encodeWithSelector(to.acceptRelayedCall.selector,
+            relay, from, encodedFunction, gasPrice, transactionFee, approval
+        );
 
-        (bool success, uint256 accept) = staticCallWithMaxGas(address(to), acceptRelayedCallMaxGas, rawTx);
+        (bool success, bytes memory returndata) = address(to).staticcall.gas(acceptRelayedCallMaxGas)(encodedTx);
 
         if (!success) {
             return uint256(PreconditionCheck.AcceptRelayedCallReverted);
         } else {
             // This can be either PreconditionCheck.OK, or a value outside of the enum range.
-            return accept;
+            return abi.decode(returndata, (uint256));
         }
-    }
-
-    // Due to a bug in Solidity v0.5.9 (https://github.com/ethereum/solidity/issues/6901) we need to implement this in
-    // assembly.
-    //
-    // Once the bug is fixed, uses of this function can be replaced by:
-    // (bool success, uint256 checkResult) = to.staticcall.gas(acceptRelayedCallMaxGas)(data);
-    function staticCallWithMaxGas(address to, uint256 maxGas, bytes memory data) private view returns (bool, uint256) {
-        bool success;
-        uint256 result;
-
-        assembly {
-            let dataSize := mload(data)
-            let dataPtr := add(data, 32)
-
-            // The 32-byte result is placed memory position 0 (scratch space)
-            success := staticcall(maxGas, to, dataPtr, dataSize, 0, 32)
-            result := mload(0)
-        }
-
-        return (success, result);
     }
 
     /**

--- a/coverage-prov.js
+++ b/coverage-prov.js
@@ -16,7 +16,7 @@ const { CoverageSubprovider } = require("@0x/sol-coverage");
 const { RevertTraceSubprovider } = require("@0x/sol-trace");
 
 const projectRoot = "";
-const solcVersion = "0.5.9"
+const solcVersion = "0.5.10"
 const defaultFromAddress = "0x5409ed021d9299bf6814279a6a1411a7e866a631";
 const isVerbose = true;
 const artifactAdapter = new TruffleArtifactAdapter(projectRoot, solcVersion);

--- a/dock/Dockerfile
+++ b/dock/Dockerfile
@@ -21,9 +21,9 @@ RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources
 RUN apt-get update && \
 	apt-get install --no-install-recommends yarn
 
-#need to select which version we install: default is (right now) 0.5.5
-RUN curl -L -o /usr/local/bin/solc-5.5 https://github.com/ethereum/solidity/releases/download/v0.5.5/solc-static-linux && chmod a+rx /usr/local/bin/solc-5.5
-RUN ln -s /usr/local/bin/solc-5.5 /usr/local/bin/solc
+#need to select which version we install: default is (right now) 0.5.10
+RUN curl -L -o /usr/local/bin/solc-5.10 https://github.com/ethereum/solidity/releases/download/v0.5.10/solc-static-linux && chmod a+rx /usr/local/bin/solc-5.10
+RUN ln -s /usr/local/bin/solc-5.10 /usr/local/bin/solc
 #RUN apt-get install -y solc
 
 ENV PS1 "\e[31min-docker\e[0m \W \$ "

--- a/truffle.js
+++ b/truffle.js
@@ -50,7 +50,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: "0.5.9",
+      version: "0.5.10",
     },
   }
 };


### PR DESCRIPTION
This upgrades the compiler version to use v0.5.10, which includes a fix for https://github.com/ethereum/solidity/issues/6901, letting us remove `staticCallWithMaxGas` and its inline assembly.