### PR TITLE
Show server errors in RelayClient

### DIFF
--- a/src/js/relayclient/RelayClient.js
+++ b/src/js/relayclient/RelayClient.js
@@ -155,8 +155,18 @@ class RelayClient {
                     console.log("sendViaRelay resp=", body)
                 }
 
-                if (!body || !body.nonce) {
+                if (!body) {
                     reject("Empty body received from server.");
+                    return
+                }
+
+                if (body.error) {
+                    reject(`Server error ${body.error}`);
+                    return
+                }
+
+                if (!body.nonce) {
+                    reject(`No transaction nonce received from server ${body}`);
                     return
                 }
 


### PR DESCRIPTION
If the server returned an error on body.error, since it was missing a body.nonce, the client would just output "empty server response", making debugging difficult. This change checks if body.error is present and shows it if so. Note that if the server returns body.error, it is assumed that the request failed.