### PR TITLE
Support setting txfee in tx options and add default value

### DIFF
--- a/src/js/relayclient/RelayClient.js
+++ b/src/js/relayclient/RelayClient.js
@@ -24,6 +24,9 @@ const DEFAULT_HTTP_TIMEOUT = 10000;
 //default gas price (unless client specifies one): the web3.eth.gasPrice*(100+GASPRICE_PERCENT)/100
 const GASPRICE_PERCENT = 20;
 
+// default relayer per-transaction fee
+const DEFAULT_TX_FEE = 12;
+
 class RelayClient {
     /**
      * create a RelayClient library object, to force contracts to go through a relay.
@@ -432,7 +435,7 @@ class RelayClient {
         let relayOptions = {
             from: params.from,
             to: params.to,
-            txfee: relayClientOptions.txfee,
+            txfee: params.txFee || params.txfee || relayClientOptions.txfee || DEFAULT_TX_FEE,
             gas_limit: params.gas && parseInt(params.gas, 16),
             gas_price: params.gasPrice && parseInt(params.gasPrice, 16)
         };


### PR DESCRIPTION
Instead of just accepting tx fee when initializing the relay provider, support specifying the txfee parameter along with from, gas, to, gasPrice, etc in each tx. Also defaults fee to 12, which is above the relayer default minFee of 11.