### PR TITLE
Fix relaydocker

### DIFF
--- a/dock/Dockerfile
+++ b/dock/Dockerfile
@@ -19,8 +19,6 @@ RUN	add-apt-repository ppa:gophers/archive &&\
 #need to select which version we install: default is (right now) 0.5.10
 RUN curl -L -o /usr/local/bin/solc-5.10 https://github.com/ethereum/solidity/releases/download/v0.5.10/solc-static-linux && chmod a+rx /usr/local/bin/solc-5.10
 RUN ln -s /usr/local/bin/solc-5.10 /usr/local/bin/solc
-#install ganache and truffle as global package
-RUN npm -g install ganache-cli truffle --unsafe-perm
 
 ENV PS1 "\e[31min-docker\e[0m \W \$ "
 RUN echo "export PS1=\"$PS1\"" >> /etc/bash.bashrc

--- a/dock/Dockerfile
+++ b/dock/Dockerfile
@@ -2,29 +2,25 @@ FROM phusion/baseimage
 MAINTAINER "dror@tabookey.com"
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
-RUN	apt-get update && \
-	apt-get install -y software-properties-common && \
-	add-apt-repository ppa:gophers/archive &&\
+RUN	add-apt-repository ppa:gophers/archive &&\
 	add-apt-repository -y ppa:ethereum/ethereum && \
 	apt-get update && \
+	apt-get install -y software-properties-common && \
 	apt-get install -y git nodejs && \
 	apt-get install -y golang-1.10-go && \
 	apt-get install -y ethereum  && \
 	apt-get install -y netcat && \
+	apt-get install --no-install-recommends yarn && \
 	rm -rf /var/lib/apt/lists/*
-
-
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-
-RUN apt-get update && \
-	apt-get install --no-install-recommends yarn
 
 #need to select which version we install: default is (right now) 0.5.10
 RUN curl -L -o /usr/local/bin/solc-5.10 https://github.com/ethereum/solidity/releases/download/v0.5.10/solc-static-linux && chmod a+rx /usr/local/bin/solc-5.10
 RUN ln -s /usr/local/bin/solc-5.10 /usr/local/bin/solc
-#RUN apt-get install -y solc
+#install ganache and truffle as global package
+RUN npm -g install ganache-cli truffle --unsafe-perm
 
 ENV PS1 "\e[31min-docker\e[0m \W \$ "
 RUN echo "export PS1=\"$PS1\"" >> /etc/bash.bashrc

--- a/dock/killdock.sh
+++ b/dock/killdock.sh
@@ -1,1 +1,1 @@
-docker rm -f run-relaydock
+docker rm -f relaydock

--- a/restart-relay.sh
+++ b/restart-relay.sh
@@ -37,7 +37,7 @@ blocktime=${T=0}
 pkill -f ganache-cli && echo killed old ganache.
 pkill -f RelayHttpServer && echo kill old relayserver
 
-GANACHE="$root/node_modules/.bin/ganache-cli -l 8000000 -b $blocktime -a 11 -h 0.0.0.0 "
+GANACHE="ganache-cli -l 8000000 -b $blocktime -a 11 -h 0.0.0.0 "
 
 if [ -n "$DEBUG" ]; then
 	$GANACHE -d --verbose &

--- a/restart-relay.sh
+++ b/restart-relay.sh
@@ -37,7 +37,7 @@ blocktime=${T=0}
 pkill -f ganache-cli && echo killed old ganache.
 pkill -f RelayHttpServer && echo kill old relayserver
 
-GANACHE="ganache-cli -l 8000000 -b $blocktime -a 11 -h 0.0.0.0 "
+GANACHE="npx ganache-cli -l 8000000 -b $blocktime -a 11 -h 0.0.0.0 "
 
 if [ -n "$DEBUG" ]; then
 	$GANACHE -d --verbose &
@@ -53,7 +53,7 @@ if ! pgrep  -f ganache > /dev/null ; then
 	exit 1
 fi
 
-hubaddr=`truffle migrate | tee /dev/stderr | grep -A 4 "RelayHub" | grep "contract address" | grep "0x.*" -o`
+hubaddr=`npx truffle migrate | tee /dev/stderr | grep -A 4 "RelayHub" | grep "contract address" | grep "0x.*" -o`
 
 if [ -z "$hubaddr" ]; then
 echo "FATAL: failed to detect RelayHub address"
@@ -72,8 +72,8 @@ cd $root
 sleep 1
 
 case "$*" in
-	test) 	cmd="truffle test" ;; 
-	test/*) cmd="truffle test $*" ;;
+	test) 	cmd="npx truffle test" ;; 
+	test/*) cmd="npx truffle test $*" ;;
 	web)	cmd="./init_metacoin.sh web" ;;
 	*)	echo "Unknown command. do '$0 help'"; exit 1 ;;
 esac

--- a/scripts/fundrelay.js
+++ b/scripts/fundrelay.js
@@ -12,7 +12,7 @@ async function fundrelay(hubaddr, relayaddr, fromaddr, fund, stake, unstakeDelay
     let rhub = new web3.eth.Contract(irelayhub, hubaddr)
 
     let curstake = await rhub.methods.stakeOf(relayaddr).call();
-    if ( curstake > 1e17 ) {
+    if ( curstake > 1e18 ) {
         console.log( "already has a stake of "+(curstake/1e18)+" eth. NOT adding more")
     } else {
         console.log( "staking ",stake)
@@ -56,8 +56,7 @@ async function run() {
     const web3 = new Web3(new Web3.providers.HttpProvider(ethNodeUrl))
 
     let accounts = await web3.eth.getAccounts()
-
-    fundrelay(hubaddr, relay, accounts[fromaccount], 1.1e18, 1.1e18, 30, web3)
+    fundrelay(hubaddr, relay, accounts[fromaccount], 1.1e18, 1.1e18, 3600 * 24 * 7, web3)
 
 }
 


### PR DESCRIPTION
fixes #162 and #163 

1. Installed `truffle` and `ganache-cli` as a global package for docker
2. Optimize dependencies installation for docker i.e. removed redundant `apt-get update` commands 
3. Updated `killdock.sh` script 
4. updated unstakeDelay value in `fundrelay` script. 