### PR TITLE
Revert "Support setting txfee in tx options (#159)"

### DIFF
--- a/src/js/relayclient/RelayClient.js
+++ b/src/js/relayclient/RelayClient.js
@@ -24,9 +24,6 @@ const DEFAULT_HTTP_TIMEOUT = 10000;
 //default gas price (unless client specifies one): the web3.eth.gasPrice*(100+GASPRICE_PERCENT)/100
 const GASPRICE_PERCENT = 20;
 
-// default relayer per-transaction fee
-const DEFAULT_TX_FEE = 12;
-
 class RelayClient {
     /**
      * create a RelayClient library object, to force contracts to go through a relay.
@@ -435,7 +432,7 @@ class RelayClient {
         let relayOptions = {
             from: params.from,
             to: params.to,
-            txfee: params.txFee || params.txfee || relayClientOptions.txfee || DEFAULT_TX_FEE,
+            txfee: relayClientOptions.txfee,
             gas_limit: params.gas && parseInt(params.gas, 16),
             gas_price: params.gasPrice && parseInt(params.gasPrice, 16)
         };


### PR DESCRIPTION
This reverts commit 21a348d2f0ba8df8065b349e8d22ec09c535c14a.

@spalladino , @shahafn :
I actually think this is wrong:
There should not be a default fee on the client.
Instead, the client should default to the fee advertised by the relay.
The user may override it with a different value (either higher or lower )

Note that a static default is bad since:

if the relay's required txfee is higher, then the transaction will be rejected by the relay.
if the relay's required tx if lower, then the user is simply over-pay.