### PR TITLE
Add dev mode to relayer server

### DIFF
--- a/prodserverdock/relay/config/relay.txt
+++ b/prodserverdock/relay/config/relay.txt
@@ -7,8 +7,8 @@
 #   	Relay's gas limit per transaction (default 100000)
 # -GasPricePercent int
 #   	Relay's gas price increase as percentage from current average. GasPrice = (100+GasPricePercent)/100 * eth_gasPrice()  (default 10)
-# -ShortSleep
-#   	Whether we wait after calls to blockchain or return (almost) immediately
+# -DevMode
+#   	Enable developer mode (do not retry unconfirmed txs, do not cache account nonce, do not wait after calls to the chain, faster polling)
 # -StakeAmount int
 #   	Relay's stake (in wei) (default 1002)
 # -UnstakeDelay int

--- a/server/src/librelay/relay_server.go
+++ b/server/src/librelay/relay_server.go
@@ -225,6 +225,10 @@ func (relay *RelayServer) ChainID() (chainID *big.Int, err error) {
 		return
 	}
 
+	if relay.DevMode && chainID.Int64() < 1000 {
+		log.Fatalf("Cowardly refusing to connect to chain with ID=%s in DevMode. Only chains with ID 1000 or higher are supported for dev mode to prevent the relay from being accidentally penalized.", chainID.String())
+	}
+
 	relay.chainID = chainID
 	return
 }

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -22,7 +22,7 @@ module.exports = {
         options = options || {}
         let args = []
         args.push("-Workdir", "./build/server")
-        args.push("-ShortSleep")
+        args.push("-DevMode")
         if (rhub) {
             args.push("-RelayHubAddress", rhub.address)
         }


### PR DESCRIPTION
Adds a new bool flag -DevMode (defaults to false). When set, the relayer does not cache its account nonce, and does not try resending unconfirmed txs. This is useful when running unit tests against a relayer instance using ganache: if the test suite rollbacks the blockchain state on each test, the relayer account nonce falls out of sync. This mode prevents this, and allows having a long-running relayer for the whole test suite.