### PR TITLE
Add destination parameter to rhub withdraw

### DIFF
--- a/contracts/IRelayHub.sol
+++ b/contracts/IRelayHub.sol
@@ -69,10 +69,10 @@ contract IRelayHub {
     // Withdraws from an account's balance, sending it back to it. Relay owners call this to retrieve their revenue, and
     // contracts can also use it to reduce their funding.
     // Emits a Withdrawn event.
-    function withdraw(uint256 amount) public;
+    function withdraw(uint256 amount, address payable dest) public;
 
     // Emitted when an account withdraws funds from RelayHub.
-    event Withdrawn(address indexed dest, uint256 amount);
+    event Withdrawn(address indexed account, address indexed dest, uint256 amount);
 
     // Relaying
 

--- a/contracts/RelayHub.sol
+++ b/contracts/RelayHub.sol
@@ -172,14 +172,14 @@ contract RelayHub is IRelayHub {
      * note that while everyone can `depositFor()` a contract, only
      * the contract itself can withdraw its funds.
      */
-    function withdraw(uint256 amount) public {
+    function withdraw(uint256 amount, address payable dest) public {
         address payable account = msg.sender;
         require(balances[account] >= amount, "insufficient funds");
 
         balances[account] -= amount;
-        account.transfer(amount);
+        dest.transfer(amount);
 
-        emit Withdrawn(account, amount);
+        emit Withdrawn(account, dest, amount);
     }
 
     function getNonce(address from) view external returns (uint256) {

--- a/contracts/SampleRecipient.sol
+++ b/contracts/SampleRecipient.sol
@@ -194,7 +194,7 @@ contract SampleRecipient is RelayRecipient, Ownable {
 
     function withdrawAllBalance() private returns (uint256) {
         uint256 balance = getRelayHub().balanceOf(address(this));
-        getRelayHub().withdraw(balance);
+        getRelayHub().withdraw(balance, address(this));
         return balance;
     }
 }

--- a/test/RelayHub.test.js
+++ b/test/RelayHub.test.js
@@ -12,7 +12,7 @@ const rlp = require('rlp');
 
 const { expect } = require('chai');
 
-contract('RelayHub', function ([_, relayOwner, relay, otherRelay, sender, other]) {  // eslint-disable-line no-unused-vars
+contract('RelayHub', function ([_, relayOwner, relay, otherRelay, sender, other, dest]) {  // eslint-disable-line no-unused-vars
   const RelayCallStatusCodes = {
     OK: new BN('0'),
     RelayedCallFailed: new BN('1'),
@@ -708,23 +708,23 @@ contract('RelayHub', function ([_, relayOwner, relay, otherRelay, sender, other]
       const amount = ether('1');
       await testDeposit(other, other, amount);
 
-      const { logs } = await relayHub.withdraw(amount.divn(2), { from: other });
-      expectEvent.inLogs(logs, 'Withdrawn', { dest: other, amount: amount.divn(2) });
+      const { logs } = await relayHub.withdraw(amount.divn(2), dest, { from: other });
+      expectEvent.inLogs(logs, 'Withdrawn', { account: other, dest, amount: amount.divn(2) });
     });
 
     it('accounts with deposits can withdraw all their balance', async function () {
       const amount = ether('1');
       await testDeposit(other, other, amount);
 
-      const { logs } = await relayHub.withdraw(amount, { from: other });
-      expectEvent.inLogs(logs, 'Withdrawn', { dest: other, amount });
+      const { logs } = await relayHub.withdraw(amount, dest, { from: other });
+      expectEvent.inLogs(logs, 'Withdrawn', { account: other, dest, amount });
     });
 
     it('accounts cannot withdraw more than their balance', async function () {
       const amount = ether('1');
       await testDeposit(other, other, amount);
 
-      await expectRevert(relayHub.withdraw(amount.addn(1), { from: other }), 'insufficient funds');
+      await expectRevert(relayHub.withdraw(amount.addn(1), dest, { from: other }), 'insufficient funds');
     });
   });
 


### PR DESCRIPTION
If a recipient wants to withdraw funds from the rhub, the contract itself needs to call the `withdraw` function on the hub, which transfers funds to the contract. This forces the contract to implement a fallback payable function (ie to accept funds) in order to receive that transfer. Adding a fallback payable function is generally not a good idea, unless there is a mechanism in place to process arbitrary payments made to the contract.

To fix this, we can add a `dest` parameter to rhub's `withdraw`, which indicates who actually receives the withdrawn funds. This removes the requirement for any recipient to have to accept (and manage) funds from any source. Old behaviour can be preserved by just specifying the contract's own address as `dest`.

We considered the alternative of adding a fallback payable function to the base Recipient with a check `require(msg.sender == rhub)`, but that still requires a separate mechanism built-in for moving those funds. We believe this solution is much cleaner, as the funds do not need to go through the recipient contract at all, and are sent directly to a target wallet.