### PR TITLE
Fix recipient balance check

### DIFF
--- a/contracts/RelayHub.sol
+++ b/contracts/RelayHub.sol
@@ -287,7 +287,7 @@ contract RelayHub is IRelayHub {
 
         // We don't yet know how much gas will be used by the recipient, so we make sure there are enough funds to pay
         // for the maximum possible charge.
-        require(gasPrice * initialGas <= balances[recipient], "Recipient balance too low");
+        require(calculateCharge(initialGas, gasPrice, transactionFee) <= balances[recipient], "Recipient balance too low");
 
         bytes4 functionSelector = LibBytes.readBytes4(encodedFunction, 0);
 

--- a/test/relay_hub_test.js
+++ b/test/relay_hub_test.js
@@ -660,7 +660,7 @@ contract("RelayHub", function (accounts) {
             /**/
             let relay_recipient_balance_before = await rhub.balanceOf(sr.address)
             if (relay_recipient_balance_before.toString() == 0) {
-                let deposit = 100000000;
+                let deposit = 1000000000;
                 await sr.deposit({value: deposit});
             }
             relay_recipient_balance_before = await rhub.balanceOf(sr.address)


### PR DESCRIPTION
The check that the recipient had enough balance for paying for a relayed tx was not considering the tx fee.