### PR TITLE
Increase short sleep interval tenfold

### DIFF
--- a/server/src/RelayHttpServer.go
+++ b/server/src/RelayHttpServer.go
@@ -52,7 +52,7 @@ func main() {
 
 	timeUnit = time.Minute
 	if devMode {
-		timeUnit = 100 * time.Millisecond
+		timeUnit = time.Second
 	}
 	stopKeepAlive = schedule(keepAlive, 60*timeUnit, 0)
 	stopRefreshBlockchainView = schedule(refreshBlockchainView, 1*timeUnit, 0)

--- a/server/src/utils.go
+++ b/server/src/utils.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-func IsEmpty(name string) (bool) {
+func IsEmpty(name string) bool {
 	f, err := os.Open(name)
 	if err != nil {
 		return true
@@ -68,7 +68,6 @@ func loadPrivateKey(keystoreDir string) *ecdsa.PrivateKey {
 	return keyWrapper.PrivateKey
 }
 
-
 func schedule(job func(), delay time.Duration, when time.Duration) chan bool {
 
 	stop := make(chan bool)
@@ -90,8 +89,8 @@ func schedule(job func(), delay time.Duration, when time.Duration) chan bool {
 
 func sleep(duration time.Duration, shortSleep bool) {
 	if shortSleep {
-		time.Sleep(100*time.Millisecond)
-	}else {
+		time.Sleep(time.Second)
+	} else {
 		time.Sleep(duration)
 	}
 }


### PR DESCRIPTION
This PR increases the short sleep interval from 100ms to 1s. When running the relayer on a CI in a large test suite (such as openzeppelin contracts), the short sleep stressed the CI and caused the entire job to timeout. Increasing the short sleep interval fixed this, by reducing the pressure on the CI runner.

Links to the relevant CI runs:
- [Without relayer](https://travis-ci.com/OpenZeppelin/openzeppelin-contracts/builds/121313660): runs in 12 min
- [With relayer on 100ms](https://travis-ci.com/OpenZeppelin/openzeppelin-contracts/builds/121809414): timeouts at 50min
- [With relayer on 1s](https://travis-ci.com/OpenZeppelin/openzeppelin-contracts/builds/121817387): runs in 28min

Note that this change does not affect this repository's test time. I run `time npm test` on this repository on my machine before and after the change, and got a 6s difference only.

```
shortsleep=1s
real	0m51.938s
user	0m17.668s
sys	0m1.659s

shortsleep=100ms
real	0m45.659s
user	0m16.724s
sys	0m1.899s
```