### PR TITLE
RelayClient: should check if "canRelay()" before calling a relay.

### DIFF
--- a/contracts/SampleRecipient.sol
+++ b/contracts/SampleRecipient.sol
@@ -131,7 +131,7 @@ contract SampleRecipient is RelayRecipient, Ownable {
         if (approvalData.length > 0) {
             // extract owner sig from all signature bytes
             if (keccak256(abi.encodePacked("I approve", from)).toEthSignedMessageHash().recover(approvalData) != owner()) {
-                return (13, "");
+                return (13, "test: not approved");
             }
         }
 

--- a/src/js/relayclient/RelayClient.js
+++ b/src/js/relayclient/RelayClient.js
@@ -51,10 +51,10 @@ class RelayClient {
     constructor(web3, config) {
         // TODO: require sign() or privKey
         //fill in defaults:
-        this.config = {
+        this.config = Object.assign( {
             validateCanRelay: true,
-            httpTimeout : DEFAULT_HTTP_TIMEOUT,
-        ...config }
+            httpTimeout : DEFAULT_HTTP_TIMEOUT
+        }, config )
 
         this.web3 = web3;
         this.httpSend = new HttpWrapper({ timeout: this.config.httpTimeout });
@@ -290,7 +290,7 @@ class RelayClient {
     async relayTransaction(encodedFunctionCall, options) {
 
         //validateCanRelay defaults (in config). to disable, explicitly set options.validateCanRelay=false
-        options = { validateCanRelay:this.config.validateCanRelay, ...options  }
+        options = Object.assign( { validateCanRelay:this.config.validateCanRelay }, options )
 
         var self = this;
         let relayRecipient = this.createRelayRecipient(options.to);

--- a/src/js/relayclient/RelayClient.js
+++ b/src/js/relayclient/RelayClient.js
@@ -24,6 +24,13 @@ const DEFAULT_HTTP_TIMEOUT = 10000;
 //default gas price (unless client specifies one): the web3.eth.gasPrice*(100+GASPRICE_PERCENT)/100
 const GASPRICE_PERCENT = 20;
 
+const canRelayStatus = {
+    1 : "1 WrongSignature",             // The transaction to relay is not signed by requested sender
+    2 : "2 WrongNonce",                 // The provided nonce has already been used by the sender
+    3 : "3 AcceptRelayedCallReverted",  // The recipient rejected this call via acceptRelayedCall
+    4 : "4 InvalidRecipientStatusCode",  // The recipient returned an invalid (reserved) status code
+}
+
 class RelayClient {
     /**
      * create a RelayClient library object, to force contracts to go through a relay.
@@ -403,8 +410,9 @@ class RelayClient {
                 ).call()
                 if ( res.status !=0 ) {
                     //in case of error, the context is an error message.
-                    let errorMsg = Buffer.from( res.recipientContext.slice(2), 'hex' ).toString();
-                    throw new Error( "canRelay failed: "+res.status+": "+errorMsg )
+                    let errorMsg = res.recipientContext ? Buffer.from( res.recipientContext.slice(2), 'hex' ).toString() : ""
+                    let status = canRelayStatus[res.status] || res.status
+                    throw new Error( "canRelay failed: "+status+": "+errorMsg )
                 }
             }
 


### PR DESCRIPTION
The client should check if the transaction it generates is valid
on-chain, before sending it to a relay.

This is done by calling the same `RelayHub.canRelay()` method used by
the relay itself to check the transaction validity.

Without this check, in case the transaction would fail, the relay would
reject it. But in this case, the client would continue to try and send
the transaction through all relays, instead of stopping after first
failure.

When signing a transaction with Metamask, this also has the side-effect
of requiring the user to confirm signing the transaction again for each
such relay access attempt.