### PR TITLE
Local dock relay should use public relay address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tabookey-gasless-*.tgz
 /coverage.json
 /artifacts/
 /webtools/tabookey-webtools.pack.js
+/singleton/

--- a/build_server_docker.sh
+++ b/build_server_docker.sh
@@ -9,15 +9,16 @@ serverbuild=./build/serverdock
 
 rm -rf $serverbuild
 mkdir $serverbuild
+./scripts/singleton/compute.sh
 
 cp ./build/dock-builD/server/bin/RelayHttpServer $serverbuild
 cp ./serverdock/package.json $serverbuild
 cp ./serverdock/start-relay.sh $serverbuild
 cp ./serverdock/start-relay-with-ganache.sh $serverbuild
-tar cf - ./scripts/fundrelay.js ./src/js/relayclient/IRelayHub.js ./contracts | tar xvf - -C $serverbuild  
+tar cf - ./scripts/singleton/deploy.js ./singleton ./scripts/fundrelay.js ./src/js/relayclient/IRelayHub.js ./contracts | tar xvf - -C $serverbuild  
 cp ./serverdock/truffle.js $serverbuild
 cp -a ./contracts $serverbuild
-cp -a ./serverdock/migrations $serverbuild
+#cp -a ./serverdock/migrations $serverbuild
 
 echo -n `git describe --dirty` > $serverbuild/version
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Tabookey Gasless Relay Framework",
   "name": "tabookey-gasless",
   "license": "MIT",

--- a/publish_server_docker.sh
+++ b/publish_server_docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -xe
 
 repository=tabookey/gsn-dev-server
 version=`docker run -t gsn-dev-server cat version`

--- a/scripts/gsn-dock-relay
+++ b/scripts/gsn-dock-relay
@@ -15,5 +15,5 @@ else
 	PORT=
 fi
 
-docker run -t --name gsn-dock --rm -p 8090:8090 $PORT tabookey/gsn-dev-server:0.4.0-beta2 $ARG
+docker run -t --name gsn-dock --rm -p 8090:8090 $PORT tabookey/gsn-dev-server:v0.4.1 $ARG
 exited=1

--- a/serverdock/Dockerfile
+++ b/serverdock/Dockerfile
@@ -15,7 +15,5 @@ RUN rm -rf node_modules/websocket
 RUN npm install openzeppelin-solidity@2.1.2 @0x/contracts-utils@3.1.1
 
 ADD . .
-ENV PATH=./node_modules/.bin:$PATH
-RUN truffle compile
 
 CMD "/start-relay.sh"

--- a/serverdock/start-relay.sh
+++ b/serverdock/start-relay.sh
@@ -16,8 +16,8 @@ else
 	network=devUseHardcodedAddress
 fi
 
-truffle migrate --network $network
-hubaddr=0x9C57C0F1965D225951FE1B2618C92Eefd687654F
+hubaddr=`perl -ne 'print $1 if /contract.*address.*?(\w+)/' < ./singleton/deploy.json`
+truffle exec --network $network ./scripts/singleton/deploy.js
 
 echo $ethereumNodeUrl
 #fund relay:


### PR DESCRIPTION
Test relay docker image (used by `npx gns-dock-relay-ganache`) should use the same
public RelayHub address used in all production networks.
