### PR TITLE
Update web3 to 1.2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@0x/contracts-utils": "3.1.1",
-    "abi-decoder": "^1.2.0",
+    "abi-decoder": "^2.2.0",
     "axios": "^0.18.0",
     "big-js": "^3.1.3",
     "big.js": "^5.2.2",
@@ -57,8 +57,8 @@
     "ethereumjs-wallet": "^0.6.3",
     "openzeppelin-solidity": "^2.3.0",
     "request-promise": "^4.2.2",
-    "web3": "1.0.0-beta.37",
-    "web3-utils": "1.0.0-beta.37",
+    "web3": "^1.2.1",
+    "web3-utils": "^1.2.1",
     "webpack-bundle-analyzer": ">=3.3.2"
   },
   "devDependencies": {
@@ -67,6 +67,7 @@
     "@0x/sol-profiler": "^3.1.7",
     "@0x/sol-trace": "^2.0.13",
     "@0x/subproviders": "^4.1.0",
+    "bignumber.js": "^9.0.0",
     "browser-request": "^0.3.3",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",


### PR DESCRIPTION
Background:
I'm using this library for my project (Burner Wallet 2), and I'm trying to reduce the size of the compiled bundle of the app. The largest cause of bundle inflation is coming from us bundling many different versions of web3, since different libraries all have different dependencies.

-----
This PR updates web3 to version 1.2, which is the LTS version. It also updates abi-decoder to bring its web3 version inline. `bignumber.js` is no longer bundled in with web3, so it is added to the devDependencies so the tests will pass.