### PR TITLE
add useGSN, approvalData options

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,7 @@ module.exports = {
     },
     "extends": "eslint:recommended",
     "parserOptions": {
-        "ecmaVersion": 2017
+        "ecmaVersion": 2018
     },
     "rules": {
         "no-console": "off",

--- a/contracts/SampleRecipient.sol
+++ b/contracts/SampleRecipient.sol
@@ -28,6 +28,8 @@ contract SampleRecipient is RelayRecipient, Ownable {
 
     bool public storeAcceptData;
 
+    bytes public expectedApprovalData;
+
     constructor() public {}
 
     function setHub(IRelayHub rhub) public {
@@ -86,6 +88,11 @@ contract SampleRecipient is RelayRecipient, Ownable {
         storeAcceptData = val;
     }
 
+    function setExpectedApprovalData(bytes memory val) public {
+        expectedApprovalData = val;
+    }
+
+
     function() external payable {}
 
     event SampleRecipientEmitted(string message, address realSender, address msgSender, address origin);
@@ -130,6 +137,12 @@ contract SampleRecipient is RelayRecipient, Ownable {
         if ( relaysWhitelist[relay] ) return (0, "");
         if (from == blacklisted) return (11, "");
         if ( rejectAcceptRelayCall ) return (12, "");
+
+        if (expectedApprovalData.length > 0) {
+            if (keccak256(expectedApprovalData) != keccak256(approvalData)) {
+                return (14, abi.encodePacked("test: unexpected approvalData: '", approvalData, "' instead of '", expectedApprovalData, "'"));
+            }
+        } else
 
         // this is an example of how the dapp can provide an offchain signature to a transaction
         if (approvalData.length > 0) {

--- a/src/js/relayclient/RelayClient.js
+++ b/src/js/relayclient/RelayClient.js
@@ -159,10 +159,11 @@ class RelayClient {
 
         return new Promise(function (resolve, reject) {
 
+
             let jsonRequestData = {
                 "encodedFunction": encodedFunction,
                 "signature": parseHexString(signature.replace(/^0x/, '')),
-                "approvalData": parseHexString(approvalData.replace(/^0x/, '')),
+                "approvalData": parseHexString(approvalData.toString('hex').replace(/^0x/, '')),
                 "from": from,
                 "to": to,
                 "gasPrice": gasprice,
@@ -357,7 +358,7 @@ class RelayClient {
                 signature = await getTransactionSignature(this.web3, options.from, hash);
             }
 
-            let approvalData = "0x";
+            let approvalData = options.approvalData || "0x";
             if (typeof options.approveFunction === "function") {
                 approvalData = "0x" + await options.approveFunction({
                     from: options.from,
@@ -476,12 +477,12 @@ class RelayClient {
         let params = payload.params[0];
         let relayClientOptions = this.config;
 
+        const {txfee, txFee, gas, gasPrice } = params;
         let relayOptions = {
-            from: params.from,
-            to: params.to,
-            txfee: params.txFee || params.txfee || relayClientOptions.txfee,
-            gas_limit: params.gas && parseInt(params.gas, 16),
-            gas_price: params.gasPrice && parseInt(params.gasPrice, 16)
+            ...params,
+            txfee: txFee || txfee || relayClientOptions.txfee,
+            gas_limit: gas && parseInt(gas, 16),
+            gas_price: gasPrice && parseInt(gasPrice, 16)
         };
 
         if (relayClientOptions.verbose)

--- a/src/js/relayclient/RelayProvider.js
+++ b/src/js/relayclient/RelayProvider.js
@@ -67,9 +67,6 @@ class RelayProvider {
         let ret=false
         if ( payload.params && payload.params[0] ) {
             let useGSN = payload.params[0].useGSN
-            if ( useGSN ) {
-                console.log( "tada")
-            }
             if ( typeof useGSN === 'undefined' ) useGSN = this.relayOptions.useGSN
             if ( typeof useGSN === 'function' ) useGSN = useGSN(payload)
             if ( typeof useGSN !== 'undefined' && !useGSN ) {

--- a/src/js/relayclient/RelayProvider.js
+++ b/src/js/relayclient/RelayProvider.js
@@ -64,8 +64,25 @@ class RelayProvider {
 
     //hook method: skip relay if the "from" address appears in optins.skipSenders
     skipRelay(payload) {
-        return !this.relayOptions.isRelayEnabled ||
-            this.relayOptions.skipSenders && this.relayOptions.skipSenders[payload.params.from]
+        let ret=false
+        if ( payload.params && payload.params[0] ) {
+            let useGSN = payload.params[0].useGSN
+            if ( useGSN ) {
+                console.log( "tada")
+            }
+            if ( typeof useGSN === 'undefined' ) useGSN = this.relayOptions.useGSN
+            if ( typeof useGSN === 'function' ) useGSN = useGSN(payload)
+            if ( typeof useGSN !== 'undefined' && !useGSN ) {
+                ret=true
+            }
+        }
+
+        if ( !ret ) {
+            ret = !this.relayOptions.isRelayEnabled ||
+                 this.relayOptions.skipSenders && this.relayOptions.skipSenders[payload.params.from]
+        }
+
+        return ret
     }
 }
 

--- a/test/flows_test.js
+++ b/test/flows_test.js
@@ -125,6 +125,49 @@ options.forEach(params => {
             }, "revert")
         })
 
+        if (params.relay) {
+            it(params.title + "wait for specific approvalData", async () => {
+                try {
+                    await sr.setExpectedApprovalData('0x414243', {from: accounts[0], useGSN: false});
+                    await sr.emitMessage("xxx", {from: gasless, approvalData: '0x414243'});
+                } catch (e) {
+                    console.log("error1: ", e)
+                    throw e
+                } finally {
+                    await sr.setExpectedApprovalData(Buffer.from(''), {from: accounts[0], useGSN: false});
+                }
+            })
+
+            it(params.title + "wait for specific approvalData as Buffer", async () => {
+                try {
+                    await sr.setExpectedApprovalData(Buffer.from('hello'), {from: accounts[0], useGSN: false});
+                    SampleRecipient.web3.currentProvider.relayOptions.isRelayEnabled = true
+                    await sr.emitMessage("xxx", {from: gasless, approvalData: Buffer.from('hello')});
+                } catch (e) {
+                    console.log("error2: ", e)
+                    throw e
+                } finally {
+                    await sr.setExpectedApprovalData(Buffer.from(''), {from: accounts[0], useGSN: false});
+                }
+
+            })
+
+            it(params.title + "fail on no approval data", async () => {
+                try {
+                    await sr.setExpectedApprovalData(Buffer.from('hello1'), {from: accounts[0], useGSN: false});
+                    await asyncShouldThrow(async () => {
+                        await sr.emitMessage("xxx", {from: gasless});
+                    }, "unexpected approvalData: '' instead of")
+                } catch (e) {
+                    console.log("error3: ", e)
+                    throw e
+                } finally {
+                    await sr.setExpectedApprovalData(Buffer.from(''), {from: accounts[0], useGSN: false});
+                }
+
+            })
+        }
+
         async function asyncShouldThrow(asyncFunc, str) {
             let msg = str || 'Error'
             let ex = null


### PR DESCRIPTION
add missing transaction options:
- useGSN - set to `false` to bypass the GSN network for this specific transaction.
- approvalData - set the `approvalData` value of the transaction. This value can be checked by the `RelayRecipient` to verify the call (e.g. some sort of signature over tx content, sender, etc)