### PR TITLE
Allow use of injected HttpWrapper throughout the RelayClient

### DIFF
--- a/src/js/relayclient/RelayClient.js
+++ b/src/js/relayclient/RelayClient.js
@@ -69,7 +69,7 @@ class RelayClient {
         }, config)
 
         this.web3 = web3;
-        this.httpSend = new HttpWrapper({timeout: this.config.httpTimeout});
+        this.httpSend = this.config.httpSend || new HttpWrapper({timeout: this.config.httpTimeout});
         this.failedRelays = {}
         this.serverHelper = this.config.serverHelper || new ServerHelper(this.httpSend, this.failedRelays, this.config);
     }


### PR DESCRIPTION
This is to allow a) testing the relay client without depending on the
relay process (as opposed to current approach of running actual relay in
a docker) and b) will eventually allow other channels of talking to
relays other then HTTP (name should be changed then)